### PR TITLE
Fix concurrency on Linux

### DIFF
--- a/pythonbinding/knx_stack.py
+++ b/pythonbinding/knx_stack.py
@@ -78,7 +78,6 @@ discover_data_event = threading.Event()
 spake_event = threading.Event()
 client_event = threading.Event()
 client_mutex = threading.Lock()
-resource_mutex = threading.Lock()
 
 ten_spaces = "          "
 
@@ -660,9 +659,7 @@ class KNXIOTStack():
         Call back handles client command callbacks.
         Client discovery/state
         **********************************"""
-        print("Acquiring Client Mutex...")
         client_mutex.acquire()
-        print("Acquired!")
         sn=""
         c_format=""
         r_id = ""
@@ -698,9 +695,7 @@ class KNXIOTStack():
         resp  = CoAPResponse(sn, cb_status, c_format, r_id, url, cb_payload_size, payload)
         self.response_array.append(resp)
         client_event.set()
-        print("Releasing Client Mutex...")
         client_mutex.release()
-        print("Released!")
 
     def resourceCB(self, anchor, uri, _rtypes, myjson):
         """ ********************************
@@ -769,7 +764,6 @@ class KNXIOTStack():
 
     def __init__(self, debug=True):
         print ("loading ...")
-        resource_mutex.acquire()
         if sys.platform == 'linux':
             libname = "libkisCS.so"
         else:

--- a/pythonbinding/knx_stack.py
+++ b/pythonbinding/knx_stack.py
@@ -660,7 +660,9 @@ class KNXIOTStack():
         Call back handles client command callbacks.
         Client discovery/state
         **********************************"""
+        print("Acquiring Client Mutex...")
         client_mutex.acquire()
+        print("Acquired!")
         sn=""
         c_format=""
         r_id = ""
@@ -696,7 +698,9 @@ class KNXIOTStack():
         resp  = CoAPResponse(sn, cb_status, c_format, r_id, url, cb_payload_size, payload)
         self.response_array.append(resp)
         client_event.set()
+        print("Releasing Client Mutex...")
         client_mutex.release()
+        print("Released!")
 
     def resourceCB(self, anchor, uri, _rtypes, myjson):
         """ ********************************

--- a/pythonbinding/oc_python.c
+++ b/pythonbinding/oc_python.c
@@ -1204,9 +1204,7 @@ func_event_thread(void *data)
   (void)data;
   oc_clock_time_t next_event;
   while (quit != 1) {
-    ets_mutex_lock(app_sync_lock);
     next_event = oc_main_poll();
-    ets_mutex_unlock(app_sync_lock);
 
     ets_mutex_lock(mutex);
     if (next_event == 0) {
@@ -1236,6 +1234,10 @@ ets_main(void)
   sa.sa_flags = 0;
   sa.sa_handler = ets_exit;
   sigaction(SIGINT, &sa, NULL);
+
+  pthread_mutex_init(&app_sync_lock, NULL);
+  pthread_mutex_init(&mutex, NULL);
+  pthread_cond_init(&cv, NULL);
 #endif
 
 #ifdef OC_SERVER


### PR DESCRIPTION
The `resource` mutex in `knx_stack.py` was locked but never released, so I have removed it.

This PR initializes the Linux mutexes in the same place where the Windows ones are initialized. It also removes the mutex around `oc_main_poll();` within `func_event_thread` - this makes consecutive calls work on Linux. The client is also protected by a mutex within Python, so it should be sound, but I am not 100% sure...