### PR TITLE
API for generating OSCORE masterkeys

### DIFF
--- a/security/oc_spake2plus.c
+++ b/security/oc_spake2plus.c
@@ -286,9 +286,9 @@ oc_spake_gen_keypair(mbedtls_mpi *y, mbedtls_ecp_point *pub_y)
                                  &ctr_drbg_ctx);
 }
 
-int oc_gen_masterkey(uint8_t array[OSCORE_IDCTX_LEN])
+int oc_gen_masterkey(uint8_t *array)
 {
-  return mbedtls_ctr_drbg_random(&ctr_drbg_ctx, array, 16);
+  return mbedtls_ctr_drbg_random(&ctr_drbg_ctx, array, OSCORE_KEY_LEN);
 }
 
 // generic formula for

--- a/security/oc_spake2plus.c
+++ b/security/oc_spake2plus.c
@@ -286,7 +286,8 @@ oc_spake_gen_keypair(mbedtls_mpi *y, mbedtls_ecp_point *pub_y)
                                  &ctr_drbg_ctx);
 }
 
-int oc_gen_masterkey(uint8_t *array)
+int
+oc_gen_masterkey(uint8_t *array)
 {
   return mbedtls_ctr_drbg_random(&ctr_drbg_ctx, array, OSCORE_KEY_LEN);
 }

--- a/security/oc_spake2plus.c
+++ b/security/oc_spake2plus.c
@@ -286,6 +286,11 @@ oc_spake_gen_keypair(mbedtls_mpi *y, mbedtls_ecp_point *pub_y)
                                  &ctr_drbg_ctx);
 }
 
+int oc_gen_masterkey(uint8_t array[OSCORE_IDCTX_LEN])
+{
+  return mbedtls_ctr_drbg_random(&ctr_drbg_ctx, array, 16);
+}
+
 // generic formula for
 // pX = pubX + wX * L
 static int

--- a/security/oc_spake2plus.h
+++ b/security/oc_spake2plus.h
@@ -84,13 +84,15 @@ const char *oc_spake_get_password();
 void oc_spake_set_password(char *new_pass);
 
 /**
- * @brief Generate a 16-byte number, suitable for use as a masterkey within OSCORE
- * secure communication.
- * 
- * oc_spake_init() MUST be called before this function can be used. If it is not called,
- * the RNG context will be uninitialised & this function should return an error.
- * 
- * @param array Array into which the masterkey will be written. Must be of length OSCORE_KEY_LEN
+ * @brief Generate a 16-byte number, suitable for use as a masterkey within
+ * OSCORE secure communication.
+ *
+ * oc_spake_init() MUST be called before this function can be used. If it is not
+ * called, the RNG context will be uninitialised & this function should return
+ * an error.
+ *
+ * @param array Array into which the masterkey will be written. Must be of
+ * length OSCORE_KEY_LEN
  * @return int Zero on success, negative MBEDTLS error code on failure.
  */
 int oc_gen_masterkey(uint8_t array[OSCORE_KEY_LEN]);

--- a/security/oc_spake2plus.h
+++ b/security/oc_spake2plus.h
@@ -89,10 +89,10 @@ void oc_spake_set_password(char *new_pass);
  * oc_spake_init() MUST be called before this function can be used. If it is not called,
  * the RNG context will be uninitialised & this function should return an error.
  * 
- * @param array Array into which the masterkey will be written. Must be of length OSCORE_IDCTX_LEN
+ * @param array Array into which the masterkey will be written. Must be of length OSCORE_KEY_LEN
  * @return int Zero on success, negative MBEDTLS error code on failure.
  */
-int oc_gen_masterkey(uint8_t array[OSCORE_IDCTX_LEN]);
+int oc_gen_masterkey(uint8_t array[OSCORE_KEY_LEN]);
 
 /**
  * @brief Calculate the w0 & L parameter

--- a/security/oc_spake2plus.h
+++ b/security/oc_spake2plus.h
@@ -20,6 +20,7 @@
 #include "mbedtls/bignum.h"
 #include "mbedtls/ecp.h"
 #include "oc_helpers.h"
+#include "oscore_constants.h"
 
 enum { kPubKeySize = 65 };
 

--- a/security/oc_spake2plus.h
+++ b/security/oc_spake2plus.h
@@ -87,7 +87,7 @@ void oc_spake_set_password(char *new_pass);
  * secure communication.
  * 
  * oc_spake_init() MUST be called before this function can be used. If it is not called,
- * the RNG context will be uninitialised & this function should return an error. 
+ * the RNG context will be uninitialised & this function should return an error.
  * 
  * @param array Array into which the masterkey will be written. Must be of length OSCORE_IDCTX_LEN
  * @return int Zero on success, negative MBEDTLS error code on failure.

--- a/security/oc_spake2plus.h
+++ b/security/oc_spake2plus.h
@@ -83,6 +83,18 @@ const char *oc_spake_get_password();
 void oc_spake_set_password(char *new_pass);
 
 /**
+ * @brief Generate a 16-byte number, suitable for use as a masterkey within OSCORE
+ * secure communication.
+ * 
+ * oc_spake_init() MUST be called before this function can be used. If it is not called,
+ * the RNG context will be uninitialised & this function should return an error. 
+ * 
+ * @param array Array into which the masterkey will be written. Must be of length OSCORE_IDCTX_LEN
+ * @return int Zero on success, negative MBEDTLS error code on failure.
+ */
+int oc_gen_masterkey(uint8_t array[OSCORE_IDCTX_LEN]);
+
+/**
  * @brief Calculate the w0 & L parameter
  *
  * Uses PBKDF2 with SHA256 & HMAC to calculate a 40-byte output which is


### PR DESCRIPTION
Adds the `oc_gen_masterkey` which uses a securely seeded PRNG to generate masterkeys suitable for OSCORE encryption.