### PR TITLE
Configure max table entries with CMake variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ set(KNX_BUILTIN_TINYCBOR ON CACHE BOOL "Use builtin TinyCBOR, as opposed to exte
 
 set(KNX_LOG_CAST_64_BIT_INTS_ENABLED OFF CACHE BOOL "Cast int64_t and uint64_t values to (int) if platform doesn't support 64 bit int format specifiers")
 
+set(KNX_GAMT_MAX_ENTRIES "" CACHE STRING "Maximum number of group address mapping table entries")
+set(KNX_GOT_MAX_ENTRIES "" CACHE STRING "Maximum number of group object table entries")
+set(KNX_GPT_MAX_ENTRIES "" CACHE STRING "Maximum number of group publisher table entries")
+set(KNX_GRT_MAX_ENTRIES "" CACHE STRING "Maximum number of group recipient table entries")
+
 include(tools/clang-tidy.cmake)
 
 if(KNX_BUILTIN_MBEDTLS)
@@ -158,6 +163,22 @@ endif()
 
 if(KNX_LOG_CAST_64_BIT_INTS_ENABLED)
     target_compile_definitions(kis-common INTERFACE KNX_LOG_CAST_64_BIT_INTS)
+endif()
+
+if(${KNX_GAMT_MAX_ENTRIES})
+    add_compile_definitions(GAMT_MAX_ENTRIES=${KNX_GAMT_MAX_ENTRIES})
+endif()
+
+if(${KNX_GOT_MAX_ENTRIES})
+    add_compile_definitions(GOT_MAX_ENTRIES=${KNX_GOT_MAX_ENTRIES})
+endif()
+
+if(${KNX_GPT_MAX_ENTRIES})
+    add_compile_definitions(GPT_MAX_ENTRIES=${KNX_GPT_MAX_ENTRIES})
+endif()
+
+if(${KNX_GRT_MAX_ENTRIES})
+    add_compile_definitions(GRT_MAX_ENTRIES=${KNX_GRT_MAX_ENTRIES})
 endif()
 
 # Client and server versions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,19 +165,19 @@ if(KNX_LOG_CAST_64_BIT_INTS_ENABLED)
     target_compile_definitions(kis-common INTERFACE KNX_LOG_CAST_64_BIT_INTS)
 endif()
 
-if(${KNX_GAMT_MAX_ENTRIES})
+if(NOT ${KNX_GAMT_MAX_ENTRIES} EQUAL "")
     add_compile_definitions(GAMT_MAX_ENTRIES=${KNX_GAMT_MAX_ENTRIES})
 endif()
 
-if(${KNX_GOT_MAX_ENTRIES})
+if(NOT ${KNX_GOT_MAX_ENTRIES} EQUAL "")
     add_compile_definitions(GOT_MAX_ENTRIES=${KNX_GOT_MAX_ENTRIES})
 endif()
 
-if(${KNX_GPT_MAX_ENTRIES})
+if(NOT ${KNX_GPT_MAX_ENTRIES} EQUAL "")
     add_compile_definitions(GPT_MAX_ENTRIES=${KNX_GPT_MAX_ENTRIES})
 endif()
 
-if(${KNX_GRT_MAX_ENTRIES})
+if(NOT ${KNX_GRT_MAX_ENTRIES} EQUAL "")
     add_compile_definitions(GRT_MAX_ENTRIES=${KNX_GRT_MAX_ENTRIES})
 endif()
 

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -65,18 +65,26 @@ typedef struct oc_group_address_mapping_table_t
                      ///< be applied for KNX Classic secure group communication.
 } oc_group_address_mapping_table_t;
 
+#ifndef GAMT_MAX_ENTRIES
 #define GAMT_MAX_ENTRIES 20
+#endif
 static oc_group_address_mapping_table_t g_groups[GAMT_MAX_ENTRIES];
 
+#ifndef GOT_MAX_ENTRIES
 #define GOT_MAX_ENTRIES 20
+#endif
 static oc_group_object_table_t g_got[GOT_MAX_ENTRIES];
 
 #ifdef OC_PUBLISHER_TABLE
+#ifndef GPT_MAX_ENTRIES
 #define GPT_MAX_ENTRIES 20
+#endif
 static oc_group_rp_table_t g_gpt[GPT_MAX_ENTRIES];
 #endif /* OC_PUBLISHER_TABLE */
 
+#ifndef GRT_MAX_ENTRIES
 #define GRT_MAX_ENTRIES 20
+#endif
 static oc_group_rp_table_t g_grt[GRT_MAX_ENTRIES];
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Maximum table entries configurable in CMake cache.

Can configure max size for:
- group address mapping table
- group object table
- group publisher table
- group recipient table