### PR TITLE
add missing headers to oc_knx_fp.h

### DIFF
--- a/api/oc_knx_fp.h
+++ b/api/oc_knx_fp.h
@@ -21,6 +21,8 @@
 #define OC_KNX_FP_INTERNAL_H
 
 #include <stddef.h>
+#include "oc_helpers.h"
+#include "oc_ri.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
@WAvdBeek this fixes a build issue in the SDK - I'm just gonna merge it once CI passes since you're away.