### PR TITLE
Fixes for Echos in multicast communication

### DIFF
--- a/api/oc_client_api.c
+++ b/api/oc_client_api.c
@@ -292,6 +292,8 @@ oc_init_multicast_update(oc_endpoint_t *mcast, const char *uri,
     i += sizeof(r);
   }
 
+  coap_new_transaction(request->mid, request->token, request->token_len, mcast);
+
   coap_set_header_uri_path(request, uri, strlen(uri));
 
   if (query) {

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1397,6 +1397,7 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
 static void
 free_client_cb(oc_client_cb_t *cb)
 {
+  OC_DBG("Freeing cb %p", cb);
   oc_list_remove(client_cbs, cb);
 #ifdef OC_BLOCK_WISE
   oc_blockwise_scrub_buffers_for_client_cb(cb);
@@ -1409,7 +1410,6 @@ free_client_cb(oc_client_cb_t *cb)
 oc_event_callback_retval_t
 oc_ri_remove_client_cb(void *data)
 {
-  OC_DBG("removing client %p", data);
   free_client_cb(data);
   return OC_EVENT_DONE;
 }
@@ -1735,6 +1735,7 @@ oc_ri_alloc_client_cb(const char *uri, oc_endpoint_t *endpoint,
                       void *user_data)
 {
   oc_client_cb_t *cb = oc_memb_alloc(&client_cbs_s);
+  OC_DBG("Allocating cb %p", cb);
   if (!cb) {
     OC_WRN("insufficient memory to add client callback");
     return cb;

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -421,18 +421,22 @@ coap_receive(oc_message_t *msg)
         // check if incoming message is from myself.
         // if so, then return with bad request
         oc_endpoint_t *my_ep = oc_connectivity_get_endpoints(0);
+
+        while (my_ep != NULL)
+        {
 #ifdef OC_DEBUG
-        if (my_ep != NULL) {
           PRINT("engine : myself:");
           PRINTipaddr(*my_ep);
           PRINT("\n");
-        }
 #endif /* OC_DEBUG */
-        if (oc_endpoint_compare_address(&msg->endpoint, my_ep) == 0) {
-          if (msg->endpoint.addr.ipv6.port == my_ep->addr.ipv6.port) {
-            OC_DBG(" same address and port: not handling message");
-            is_myself = true;
+          if (oc_endpoint_compare_address(&msg->endpoint, my_ep) == 0) {
+            if (msg->endpoint.addr.ipv6.port == my_ep->addr.ipv6.port) {
+              OC_DBG(" same address and port: not handling message");
+              is_myself = true;
+              break;
+            }
           }
+        my_ep = my_ep->next;
         }
 
         // server-side logic for handling responses with echo option

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -403,7 +403,6 @@ coap_receive(oc_message_t *msg)
       transaction =
         coap_new_transaction(response->mid, NULL, 0, &msg->endpoint);
       if (transaction) {
-        /*
         bool new_sender = true;
         for (int i = 0; i < OC_SEEN_SENDERS_SIZE; ++i) {
           if (memcmp(seen_senders[i].address, msg->endpoint.addr.ipv6.address,
@@ -413,10 +412,9 @@ coap_receive(oc_message_t *msg)
             break;
           }
         }
-        */
 
         // For debugging: trust all senders to turn off Unauthorised Echo requests
-        bool new_sender = false;
+        //bool new_sender = false;
 
         bool is_myself = false;
         //

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -434,10 +434,6 @@ coap_receive(oc_message_t *msg)
           }
         }
 
-        // temporary: disable requesting echos from peers by trusting
-        // every device
-        new_sender = false;
-
         // server-side logic for handling responses with echo option
         if (new_sender && msg->endpoint.flags & OSCORE_DECRYPTED &&
             is_myself == false) {

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -364,7 +364,6 @@ coap_receive(oc_message_t *msg)
       }
       PRINT("  URL: %.*s", (int)message->uri_path_len, message->uri_path);
       PRINT("  QUERY: %.*s", (int)message->uri_query_len, message->uri_query);
-      PRINT("  Payload: %.*s", (int)message->payload_len, message->payload);
 #endif
       const char *href;
       size_t href_len = coap_get_header_uri_path(message, &href);
@@ -403,8 +402,8 @@ coap_receive(oc_message_t *msg)
       /* create transaction for response */
       transaction =
         coap_new_transaction(response->mid, NULL, 0, &msg->endpoint);
-
       if (transaction) {
+        /*
         bool new_sender = true;
         for (int i = 0; i < OC_SEEN_SENDERS_SIZE; ++i) {
           if (memcmp(seen_senders[i].address, msg->endpoint.addr.ipv6.address,
@@ -414,6 +413,10 @@ coap_receive(oc_message_t *msg)
             break;
           }
         }
+        */
+
+        // For debugging: trust all senders to turn off Unauthorised Echo requests
+        bool new_sender = false;
 
         bool is_myself = false;
         //

--- a/messaging/coap/transactions.c
+++ b/messaging/coap/transactions.c
@@ -206,13 +206,13 @@ coap_send_transaction(coap_transaction_t *t)
 
     // - client (PB) sends NON request, and then deletes the transaction
     // - server (SA) receives it, sends 4.01 Unauthorised w. Echo option
-    // - client (PB) receives 4.01 unauthorised, searches transactions 
+    // - client (PB) receives 4.01 unauthorised, searches transactions
     //   matching the token, but cannot find any as it was deleted by the
     //   line below!!
     //
     // So, do not clear the transaction here, but instead free this trans-
     // action in a delayed callback
-    //coap_clear_transaction(t);
+    // coap_clear_transaction(t);
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/messaging/coap/transactions.c
+++ b/messaging/coap/transactions.c
@@ -114,9 +114,10 @@ coap_new_transaction(uint16_t mid, uint8_t *token, uint8_t token_len,
   return t;
 }
 
-static oc_event_callback_retval_t clear_transaction_cb(void *transaction)
+static oc_event_callback_retval_t
+clear_transaction_cb(void *transaction)
 {
-  coap_clear_transaction((coap_transaction_t*) transaction);
+  coap_clear_transaction((coap_transaction_t *)transaction);
   return OC_EVENT_DONE;
 }
 
@@ -218,7 +219,7 @@ void
 coap_clear_transaction(coap_transaction_t *t)
 {
   // to prevent double frees
-  //oc_remove_delayed_callback(t, clear_transaction_cb);
+  // oc_remove_delayed_callback(t, clear_transaction_cb);
   if (t) {
     OC_DBG("Freeing transaction %u: %p", t->mid, (void *)t);
 

--- a/messaging/coap/transactions.c
+++ b/messaging/coap/transactions.c
@@ -218,7 +218,7 @@ void
 coap_clear_transaction(coap_transaction_t *t)
 {
   // to prevent double frees
-  oc_remove_delayed_callback(t, clear_transaction_cb);
+  //oc_remove_delayed_callback(t, clear_transaction_cb);
   if (t) {
     OC_DBG("Freeing transaction %u: %p", t->mid, (void *)t);
 

--- a/messaging/coap/transactions.c
+++ b/messaging/coap/transactions.c
@@ -204,7 +204,15 @@ coap_send_transaction(coap_transaction_t *t)
 
     coap_send_message(t->message);
 
-    coap_clear_transaction(t);
+    // - client (PB) sends NON request, and then deletes the transaction
+    // - server (SA) receives it, sends 4.01 Unauthorised w. Echo option
+    // - client (PB) receives 4.01 unauthorised, searches transactions 
+    //   matching the token, but cannot find any as it was deleted by the
+    //   line below!!
+    //
+    // So, do not clear the transaction here, but instead free this trans-
+    // action in a delayed callback
+    //coap_clear_transaction(t);
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -203,6 +203,8 @@ oc_oscore_recv_message(oc_message_t *message)
 
         oc_endpoint_set_serial_number(&message->endpoint,
                                       (char *)oscore_ctx->token_id);
+        message->endpoint.group_address = oscore_pkt->kid[0];
+
         // oc_string_copy_from_char(&message->endpoint.serial_number,
         //                         (char *)oscore_ctx->token_id);
       }

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -256,6 +256,7 @@ oc_oscore_recv_message(oc_message_t *message)
         if (check_if_replayed_request(oscore_ctx, piv, &message->endpoint,
                                       &message->mcast_dest)) {
           oscore_send_error(oscore_pkt, UNAUTHORIZED_4_01, &message->endpoint);
+          OC_ERR("***replayed request according to PIV***");
           goto oscore_recv_error;
         }
 
@@ -395,7 +396,10 @@ oc_oscore_recv_message(oc_message_t *message)
   /* Dispatch oc_message_t to the CoAP layer */
   if (oc_process_post(&coap_engine, oc_events[INBOUND_RI_EVENT], message) ==
       OC_PROCESS_ERR_FULL) {
-    goto oscore_recv_error;
+    {
+      OC_ERR("***Error dispatching decrypted CoAP message***");
+      goto oscore_recv_error;
+    }
   }
   return 0;
 


### PR DESCRIPTION
This pull request should fix [Luca's persistence issue](https://github.com/KNX-IOT/knx-iot-point-api-config/issues/47), though it is still WIP and a little bit unstable.

It adds a missing group address to the endpoint so that it can be used by higher level code. Right now this is done in a simplified way - the correct approach would be to use `oc_oscore_find_context_by_kid` to get the index of the auth table that was used to generate the context, and then obtain the actual group address by querying the auth table entry with said index.

It also enables transactions for S-mode messages, so that the Echo retransmissions can take place. Right now, the transactions on the client (push button) aren't really freed when they should be, so there is likely a memory leak. The correct behaviour would be to free the transaction after the retransmission with the included echo, and also with a delayed callback & a timeout for the general case where a retransmission is not necessary.