### PR TITLE
Valgrind fixes

### DIFF
--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1093,14 +1093,14 @@ oc_at_dump_entry(size_t device_index, int entry)
   oc_rep_i_set_int(root, 38, g_at_entries[entry].profile);
 
   oc_rep_i_set_byte_string(root, 840, oc_string(g_at_entries[entry].osc_id),
-                           oc_string_len(g_at_entries[entry].osc_contextid));
+                           oc_string_len(g_at_entries[entry].osc_id));
   oc_rep_i_set_byte_string(root, 842, oc_string(g_at_entries[entry].osc_ms),
                            oc_string_len(g_at_entries[entry].osc_ms));
   oc_rep_i_set_byte_string(root, 844, oc_string(g_at_entries[entry].osc_alg),
                            oc_string_len(g_at_entries[entry].osc_alg));
   oc_rep_i_set_byte_string(root, 846,
                            oc_string(g_at_entries[entry].osc_contextid),
-                           oc_string_len(g_at_entries[entry].osc_id));
+                           oc_string_len(g_at_entries[entry].osc_contextid));
   oc_rep_i_set_text_string(root, 82, oc_string(g_at_entries[entry].sub));
   oc_rep_i_set_text_string(root, 81, oc_string(g_at_entries[entry].kid));
 

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -308,16 +308,11 @@ void
 oc_resource_bind_dpt(oc_resource_t *resource, const char *dpt)
 {
   if (resource) {
+    oc_free_string(&resource->dpt);
+    memset(&resource->dpt, 0, sizeof(oc_string_t));
     if (dpt) {
-      if (oc_string_len(resource->dpt)) {
-        oc_free_string(&resource->dpt);
-        memset(&resource->dpt, 0, sizeof(oc_string_t));
-      }
       oc_new_string(&resource->dpt, dpt, strlen(dpt));
-    } else {
-      memset(&resource->dpt, 0, sizeof(oc_string_t));
     }
-
   } else {
     OC_ERR("oc_resource_bind_dpt: resource is NULL");
   }


### PR DESCRIPTION
This PR addresses a couple issues identified by Valgrind while running knx_iot_virtual_sa:
- the lengths in certain access token strings were incorrect
- 8 bytes of memory were lost

Note that the last error is still taking place, though I think it should be gone... @WAvdBeek can you check that my changes to `oc_resource_bind_dpt` make sense?