### PR TITLE
minor fix to DNS-SD implementation

### DIFF
--- a/port/linux/dns-sd.c
+++ b/port/linux/dns-sd.c
@@ -58,9 +58,6 @@ knx_publish_service(char *serial_no, uint32_t iid, uint32_t ia, bool pm)
 
     char *pm_subtype = "--subtype=_pm._sub._knx._udp";
 
-    snprintf(serial_no_hostname, sizeof(serial_no_hostname), "knx-%s",
-             serial_no);
-
     uint16_t port = get_ip_context_for_device(0)->port;
     snprintf(port_str, sizeof(port), "%d", port);
 
@@ -73,7 +70,7 @@ knx_publish_service(char *serial_no, uint32_t iid, uint32_t ia, bool pm)
                        serial_no_subtype,
                        pm_subtype, // programming mode is true - we publish the
                                    // _ia0 subtype too
-                       serial_no_hostname, // service name = serial number
+                       serial_no, // service name = serial number
                        "_knx._udp",        // service type
                        port_str,           // port
                        (char *)NULL);
@@ -88,7 +85,7 @@ knx_publish_service(char *serial_no, uint32_t iid, uint32_t ia, bool pm)
                  serial_no_subtype, installation_subtype,
                  pm_subtype, // programming mode is true - publish _ia0 even
                              // though we have an installation already
-                 serial_no_hostname, // service name = serial number
+                 serial_no, // service name = serial number
                  "_knx._udp",        // service type
                  port_str,           // port
                  (char *)NULL);
@@ -96,7 +93,7 @@ knx_publish_service(char *serial_no, uint32_t iid, uint32_t ia, bool pm)
     } else {
       if (!iid || !ia) {
         error = execlp("avahi-publish-service", "avahi-publish-service",
-                       serial_no_subtype, serial_no_hostname, "_knx._udp",
+                       serial_no_subtype, serial_no, "_knx._udp",
                        port_str, (char *)NULL);
       } else {
         // --subtype=_ia3333-CA._sub._knx._udp
@@ -106,7 +103,7 @@ knx_publish_service(char *serial_no, uint32_t iid, uint32_t ia, bool pm)
 
         error = execlp("avahi-publish-service", "avahi-publish-service",
                        serial_no_subtype, installation_subtype,
-                       serial_no_hostname, "_knx._udp", port_str, (char *)NULL);
+                       serial_no, "_knx._udp", port_str, (char *)NULL);
       }
     }
     if (error == -1) {

--- a/port/windows/dns-sd.c
+++ b/port/windows/dns-sd.c
@@ -43,8 +43,6 @@ knx_publish_service(char *serial_no, uint32_t iid, uint32_t ia, bool pm)
   uint16_t port = get_ip_context_for_device(0)->port;
   snprintf(port_str, sizeof(port), "%d", port);
 
-  snprintf(prefixed_serial_no, sizeof(prefixed_serial_no), "knx-%s", serial_no);
-
   char *pm_subtype;
   if (pm)
     pm_subtype = ",_pm";
@@ -54,12 +52,12 @@ knx_publish_service(char *serial_no, uint32_t iid, uint32_t ia, bool pm)
   if (iid == 0 || ia == 0) {
     sprintf(subtypes, "_knx._udp,_%s%s", serial_no, pm_subtype);
     process_handle =
-      _spawnlp(_P_NOWAIT, "dns-sd", "dns-sd", "-R", prefixed_serial_no,
+      _spawnlp(_P_NOWAIT, "dns-sd", "dns-sd", "-R", serial_no,
                subtypes, "local", port_str, NULL);
   } else {
     sprintf(subtypes, "_knx._udp,__ia%x-%x%s", iid, ia, pm_subtype);
     process_handle =
-      _spawnlp(_P_NOWAIT, "dns-sd", "dns-sd", "-R", prefixed_serial_no,
+      _spawnlp(_P_NOWAIT, "dns-sd", "dns-sd", "-R", serial_no,
                subtypes, "local", port_str, NULL);
   }
 #endif /* OC_DNS_SD */


### PR DESCRIPTION
The _hostname_ of the device must be of the format `knx-{serial_number}`. On Windows and Linux, this would be the hostname of the computer that the KNX app is running from, and is a system property that we don't really want to change from the KNX application as it would interfere with testing on the local network.

The _service name_ is what is first discovered by DNS-SD, and looks like `{serial_number}._knx._udp.local.` . This should not have the `knx-` prefix as KNX is already in the subtype, and this is what the pull request fixes.