### PR TITLE
correct port advertised by MDNS

### DIFF
--- a/port/linux/dns-sd.c
+++ b/port/linux/dns-sd.c
@@ -59,7 +59,7 @@ knx_publish_service(char *serial_no, uint32_t iid, uint32_t ia, bool pm)
     char *pm_subtype = "--subtype=_pm._sub._knx._udp";
 
     uint16_t port = get_ip_context_for_device(0)->port;
-    snprintf(port_str, sizeof(port), "%d", port);
+    snprintf(port_str, sizeof(port_str), "%d", port);
 
     int error;
     if (pm) {

--- a/port/windows/dns-sd.c
+++ b/port/windows/dns-sd.c
@@ -41,7 +41,7 @@ knx_publish_service(char *serial_no, uint32_t iid, uint32_t ia, bool pm)
   }
 
   uint16_t port = get_ip_context_for_device(0)->port;
-  snprintf(port_str, sizeof(port), "%d", port);
+  snprintf(port_str, sizeof(port_str), "%d", port);
 
   char *pm_subtype;
   if (pm)


### PR DESCRIPTION
Passed the wrong buffer size, causing only the first digit of the port to be advertised.