### PR TITLE
Add APIs for getting the buffers in which received data is stored

### DIFF
--- a/api/oc_blockwise.c
+++ b/api/oc_blockwise.c
@@ -396,3 +396,24 @@ oc_blockwise_handle_block(oc_blockwise_state_t *buffer,
   return true;
 }
 #endif /* OC_BLOCK_WISE */
+
+oc_blockwise_request_state_t *oc_get_request_buffer_with_ptr(uint8_t* data){
+  struct oc_memb *pool = &oc_blockwise_request_states_s;
+  for(size_t i = 0; i < pool->num; ++i)
+  {
+    // unused block, should not contain data of a valid message
+    if (pool->count[i] <= 0)
+      continue;
+
+    
+    int offset = i * (int)pool->size;
+    oc_blockwise_request_state_t *state = (oc_blockwise_request_state_t *)((char *)pool->mem + offset);
+
+    if (state->base.buffer <= data && data < state->base.buffer + state->base.payload_size)
+    {
+      // data lies within msg, so we return it
+      return state;
+    }
+  }
+  return NULL;
+}

--- a/api/oc_blockwise.c
+++ b/api/oc_blockwise.c
@@ -397,23 +397,17 @@ oc_blockwise_handle_block(oc_blockwise_state_t *buffer,
 }
 #endif /* OC_BLOCK_WISE */
 
-oc_blockwise_request_state_t *oc_get_request_buffer_with_ptr(uint8_t* data){
-  struct oc_memb *pool = &oc_blockwise_request_states_s;
-  for(size_t i = 0; i < pool->num; ++i)
+oc_blockwise_state_t *oc_get_request_buffer_with_ptr(uint8_t* data){
+  oc_blockwise_state_t *state = oc_list_head(oc_blockwise_requests);
+
+  while (state)
   {
-    // unused block, should not contain data of a valid message
-    if (pool->count[i] <= 0)
-      continue;
-
-    
-    int offset = i * (int)pool->size;
-    oc_blockwise_request_state_t *state = (oc_blockwise_request_state_t *)((char *)pool->mem + offset);
-
-    if (state->base.buffer <= data && data < state->base.buffer + state->base.payload_size)
+    if (state->buffer <= data && data < state->buffer + state->payload_size)
     {
       // data lies within msg, so we return it
       return state;
     }
+    state = state->next;
   }
   return NULL;
 }

--- a/api/oc_buffer.c
+++ b/api/oc_buffer.c
@@ -249,7 +249,7 @@ OC_PROCESS_THREAD(message_buffer_handler, ev, data)
   OC_PROCESS_END();
 }
 
-oc_message_t *oc_get_incoming_message_with_ptr(void* data){
+oc_message_t *oc_get_incoming_message_with_ptr(uint8_t* data){
   struct oc_memb *pool = &oc_incoming_buffers;
   for(size_t i = 0; i < pool->num; ++i)
   {

--- a/api/oc_buffer.c
+++ b/api/oc_buffer.c
@@ -248,3 +248,24 @@ OC_PROCESS_THREAD(message_buffer_handler, ev, data)
   }
   OC_PROCESS_END();
 }
+
+oc_message_t *oc_get_incoming_message_with_ptr(void* data){
+  struct oc_memb *pool = &oc_incoming_buffers;
+  for(size_t i = 0; i < pool->num; ++i)
+  {
+    // unused block, should not contain data of a valid message
+    if (pool->count[i] <= 0)
+      continue;
+
+    
+    int offset = i * (int)pool->size;
+    oc_message_t *msg = (oc_message_t *)((char *)pool->mem + offset);
+
+    if (msg->data <= data && data < msg->data + msg->length)
+    {
+      // data lies within msg, so we return it
+      return msg;
+    }
+  }
+  return NULL;
+}

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1196,7 +1196,8 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
 
 #if defined(OC_BLOCK_WISE)
   oc_blockwise_free_request_buffer(*request_state);
-  *request_state = NULL;
+  (*request_state)->ref_count--;
+  oc_blockwise_scrub_buffers(false);
 #endif
 
   if (request_obj.request_payload) {

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1195,8 +1195,6 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
   }
 
 #if defined(OC_BLOCK_WISE)
-  if (*request_state)
-    (*request_state)->ref_count--;
   oc_blockwise_scrub_buffers(false);
 #endif
 

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1195,7 +1195,6 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
   }
 
 #if defined(OC_BLOCK_WISE)
-  oc_blockwise_free_request_buffer(*request_state);
   (*request_state)->ref_count--;
   oc_blockwise_scrub_buffers(false);
 #endif

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1195,7 +1195,8 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
   }
 
 #if defined(OC_BLOCK_WISE)
-  (*request_state)->ref_count--;
+  if (*request_state)
+    (*request_state)->ref_count--;
   oc_blockwise_scrub_buffers(false);
 #endif
 

--- a/include/oc_blockwise.h
+++ b/include/oc_blockwise.h
@@ -266,6 +266,14 @@ void oc_blockwise_scrub_buffers(bool all);
  */
 void oc_blockwise_scrub_buffers_for_client_cb(void *cb);
 
+/**
+ * @brief get blockwise buffer that contains data in its payload
+ * 
+ * @param data pointer suspected to be inside a blockwise buffer
+ * @return oc_blockwise_request_state_t* the blockwise state that contains the data, or NULL if not found
+ */
+oc_blockwise_request_state_t *oc_get_request_buffer_with_ptr(uint8_t* data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/oc_blockwise.h
+++ b/include/oc_blockwise.h
@@ -272,7 +272,7 @@ void oc_blockwise_scrub_buffers_for_client_cb(void *cb);
  * @param data pointer suspected to be inside a blockwise buffer
  * @return oc_blockwise_request_state_t* the blockwise state that contains the data, or NULL if not found
  */
-oc_blockwise_request_state_t *oc_get_request_buffer_with_ptr(uint8_t* data);
+oc_blockwise_state_t *oc_get_request_buffer_with_ptr(uint8_t* data);
 
 #ifdef __cplusplus
 }

--- a/port/oc_connectivity.h
+++ b/port/oc_connectivity.h
@@ -134,6 +134,15 @@ struct oc_message_s
 int oc_send_buffer(oc_message_t *message);
 
 /**
+ * @brief get buffer of a received message
+ * 
+ * @param data pointer to data within a received message
+ * @return oc_message_t* the buffer containing the data, or NULL if such a buffer could not be found
+ */
+oc_message_t *oc_get_incoming_message_with_ptr(void* data);
+
+
+/**
  * @brief initialize the connectivity (e.g. open sockets) for the device
  *
  * @param device the device index

--- a/port/oc_connectivity.h
+++ b/port/oc_connectivity.h
@@ -139,8 +139,7 @@ int oc_send_buffer(oc_message_t *message);
  * @param data pointer to data within a received message
  * @return oc_message_t* the buffer containing the data, or NULL if such a buffer could not be found
  */
-oc_message_t *oc_get_incoming_message_with_ptr(void* data);
-
+oc_message_t *oc_get_incoming_message_with_ptr(uint8_t* data);
 
 /**
  * @brief initialize the connectivity (e.g. open sockets) for the device

--- a/util/oc_memb.h
+++ b/util/oc_memb.h
@@ -112,10 +112,15 @@ typedef void (*oc_memb_buffers_avail_callback_t)(int);
 
 struct oc_memb
 {
+  /** Size of each memory block contained within mem (e.g. sizeof(mem[0])) */
   unsigned short size;
+  /** Number of memory blocks held within the mem array */
   unsigned short num;
+  /** Array of reference counts to memory blocks */
   char *count;
+  /** Array of memory blocks */
   void *mem;
+  /** Called when the number of available buffers changes */
   oc_memb_buffers_avail_callback_t buffers_avail_cb;
 };
 


### PR DESCRIPTION
This is useful for avoiding copies while dealing with large payloads: instead of making a copy of such data, you can now use the handles (pointers) to these buffers and ask the stack to hold onto them for longer, which gives a lot more flexibility while writing application code.