### PR TITLE
Include token within ACKs that accept separate responses

### DIFF
--- a/messaging/coap/coap.c
+++ b/messaging/coap/coap.c
@@ -1130,7 +1130,7 @@ coap_oscore_serialize_message(void *packet, uint8_t *buffer, bool inner,
   }
 
   /* empty packet, don't need to do more stuff */
-  if (outer && !coap_pkt->code) {
+  if (outer && !coap_pkt->code && coap_pkt->token_len == 0) {
     OC_DBG("Done serializing empty message at %p-", coap_pkt->buffer);
     return token_location;
   } else if (outer) {

--- a/messaging/coap/separate.c
+++ b/messaging/coap/separate.c
@@ -139,6 +139,7 @@ coap_separate_accept(void *request, oc_separate_response_t *separate_response,
     coap_udp_init_message(ack, COAP_TYPE_ACK, 0, coap_req->mid);
     ack->token_len = separate_store->token_len;
     memcpy(ack->token, separate_store->token, ack->token_len);
+
     oc_message_t *message = oc_internal_allocate_outgoing_message();
     if (message != NULL) {
       memcpy(&message->endpoint, endpoint, sizeof(oc_endpoint_t));

--- a/messaging/coap/separate.c
+++ b/messaging/coap/separate.c
@@ -137,6 +137,8 @@ coap_separate_accept(void *request, oc_separate_response_t *separate_response,
     coap_packet_t ack[1];
     /* ACK with empty code (0) */
     coap_udp_init_message(ack, COAP_TYPE_ACK, 0, coap_req->mid);
+    ack->token_len = separate_store->token_len;
+    memcpy(ack->token, separate_store->token, ack->token_len);
     oc_message_t *message = oc_internal_allocate_outgoing_message();
     if (message != NULL) {
       memcpy(&message->endpoint, endpoint, sizeof(oc_endpoint_t));


### PR DESCRIPTION
Most of the code for this feature was already there: the correct token is being tracked, but it was not copied into the `coap_pkt` data structure which is serialized for the response. There was a minor bug in the serialization code too, which this PR also fixes.