### PR TITLE
remove structure size modification based on OC_OSCORE

### DIFF
--- a/include/oc_endpoint.h
+++ b/include/oc_endpoint.h
@@ -93,11 +93,9 @@ typedef struct oc_endpoint_t
                        being used to find back the OSCORE
                   credential to be used for encryption for s-mode messages
                   e.g. looping over the list of group addresses of the key */
-#ifdef OC_OSCORE
   int32_t aut_at_index; /**< auth at index +1 [1-max_indexes], 0 == error */
   uint8_t piv[OSCORE_PIV_LEN]; /**< OSCORE partial iv */
   uint8_t piv_len;             /**< OSCORE partial iv length */
-#endif                         /* OC_OSCORE */
 } oc_endpoint_t;
 
 #define oc_make_ipv4_endpoint(__name__, __flags__, __port__, ...)              \

--- a/include/oc_endpoint.h
+++ b/include/oc_endpoint.h
@@ -23,9 +23,8 @@
 
 #include "oc_helpers.h"
 #include "oc_uuid.h"
-#ifdef OC_OSCORE
+
 #include "messaging/coap/oscore_constants.h"
-#endif /* OC_OSCORE */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/oc_endpoint.h
+++ b/include/oc_endpoint.h
@@ -92,7 +92,7 @@ typedef struct oc_endpoint_t
                        being used to find back the OSCORE
                   credential to be used for encryption for s-mode messages
                   e.g. looping over the list of group addresses of the key */
-  int32_t aut_at_index; /**< auth at index +1 [1-max_indexes], 0 == error */
+  int32_t aut_at_index;   /**< auth at index +1 [1-max_indexes], 0 == error */
   uint8_t piv[OSCORE_PIV_LEN]; /**< OSCORE partial iv */
   uint8_t piv_len;             /**< OSCORE partial iv length */
 } oc_endpoint_t;


### PR DESCRIPTION
Pre-emptively fixes a bug we would see with the (new) embedded build