### PR TITLE
Fixes bad length for osc.id and contextid

### DIFF
--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1506,8 +1506,8 @@ oc_oscore_set_auth(char *serial_number, char *context_id, uint8_t *shared_key,
   oc_new_string(&os_token.osc_ms, (char *)shared_key, shared_key_size);
   // TODO this is the default, when no context_id is supplied
   // oc_new_string(&os_token.osc_id, "rkey", strlen("rkey"));
-  oc_new_byte_string(&os_token.osc_id, context_id, strlen(context_id));
-  oc_new_byte_string(&os_token.osc_contextid, context_id, strlen(context_id));
+  oc_new_string(&os_token.osc_id, context_id, strlen(context_id));
+  oc_new_string(&os_token.osc_contextid, context_id, strlen(context_id));
   oc_new_string(&os_token.sub, "", strlen(""));
 
   int index = oc_core_find_at_entry_with_context_id(0, context_id);


### PR DESCRIPTION
osc:id and osc:contextid are truncating final character, e.g.
When trying to enrol a device with serial number `sn:00FA1001230000`, the following happens:
```
Rx: oc_oscore_set_auth sn:00FA1001230000 ci:00FA1001230000
Rx:   at index: 0
Rx:     id (0)        : 00FA1001230000
Rx:     scope (9)     : 2144
Rx:     profile (38)  : 2 (coap_oscore)
Rx:     osc:id        : 00FA100123000
Rx:     osc:ms        : 1963e418c8e5fed6eb8fcb44b5059b54
Rx:     osc:contextid : 00FA100123000
Rx: -----oc_oscore_add_context---00FA100123000