### PR TITLE
Security changes for spec 1.1

### DIFF
--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -423,8 +423,7 @@ oc_wkcore_discovery_handler(oc_request_t *request,
     bool frame_ep = false;
     /* new style release 1.1 */
     /* request for all devices via serial number wild card*/
-    // example:    knx://ia.d773e094b6.1101
-    //char *ep_ia = ep_request + 9;
+    /* example:     knx://ia.d773e094b6.1101 */
     char *ep_ia = ep_request + 20; // at the end, after the second dot
     uint32_t ia = strtol(ep_ia, NULL, 16);
     if (ia == device->ia) {

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -423,7 +423,9 @@ oc_wkcore_discovery_handler(oc_request_t *request,
     bool frame_ep = false;
     /* new style release 1.1 */
     /* request for all devices via serial number wild card*/
-    char *ep_ia = ep_request + 9;
+    // example:    knx://ia.d773e094b6.1101
+    //char *ep_ia = ep_request + 9;
+    char *ep_ia = ep_request + 20; // at the end, after the second dot
     uint32_t ia = atoi(ep_ia);
     if (ia == device->ia) {
       // ia is the same

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -426,7 +426,7 @@ oc_wkcore_discovery_handler(oc_request_t *request,
     // example:    knx://ia.d773e094b6.1101
     //char *ep_ia = ep_request + 9;
     char *ep_ia = ep_request + 20; // at the end, after the second dot
-    uint32_t ia = atoi(ep_ia);
+    uint32_t ia = strtol(ep_ia, NULL, 16);
     if (ia == device->ia) {
       // ia is the same
       // now do the extra work to check the iid

--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -1346,7 +1346,7 @@ oc_core_knx_spake_post_handler(oc_request_t *request,
               (int)oc_byte_string_len(rep->value.string));
       }
     } break;
-  case OC_REP_STRING: {
+    case OC_REP_STRING: {
       if (rep->iname == SPAKE_ID) {
         // if the ID is present, overwrite the default
         oc_free_string(&g_pase.id);
@@ -1356,7 +1356,7 @@ oc_core_knx_spake_post_handler(oc_request_t *request,
               (int)oc_byte_string_len(rep->value.string));
       }
     } break;
-  default:
+    default:
       break;
     }
     rep = rep->next;
@@ -1501,10 +1501,9 @@ oc_core_knx_spake_separate_post_handler(void *req_p)
     oc_device_info_t *device = oc_core_get_device_info(0);
     // serial number should be supplied as string array
     PRINT("CLIENT: pase.id length: %d\n", (int)oc_byte_string_len(g_pase.id));
-    oc_oscore_set_auth_device(
-      oc_string(g_pase.id), oc_byte_string_len(g_pase.id),
-      "", 0,
-     shared_key, (int)shared_key_len);
+    oc_oscore_set_auth_device(oc_string(g_pase.id),
+                              oc_byte_string_len(g_pase.id), "", 0, shared_key,
+                              (int)shared_key_len);
 
     // empty payload
     oc_send_empty_separate_response(&spake_separate_rsp, OC_STATUS_CHANGED);

--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -1346,7 +1346,17 @@ oc_core_knx_spake_post_handler(oc_request_t *request,
               (int)oc_byte_string_len(rep->value.string));
       }
     } break;
-    default:
+  case OC_REP_STRING: {
+      if (rep->iname == SPAKE_ID) {
+        // if the ID is present, overwrite the default
+        oc_free_string(&g_pase.id);
+        oc_new_byte_string(&g_pase.id, oc_string(rep->value.string),
+                           oc_string_len(rep->value.string));
+        PRINT("==> CLIENT RECEIVES %d\n",
+              (int)oc_byte_string_len(rep->value.string));
+      }
+    } break;
+  default:
       break;
     }
     rep = rep->next;

--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -1492,9 +1492,9 @@ oc_core_knx_spake_separate_post_handler(void *req_p)
     // serial number should be supplied as string array
     PRINT("CLIENT: pase.id length: %d\n", (int)oc_byte_string_len(g_pase.id));
     oc_oscore_set_auth_device(
-      oc_string(device->serialnumber), oc_string_len(device->serialnumber),
-      oc_string(g_pase.id), oc_byte_string_len(g_pase.id), shared_key,
-      (int)shared_key_len);
+      oc_string(g_pase.id), oc_byte_string_len(g_pase.id),
+      "", 0,
+     shared_key, (int)shared_key_len);
 
     // empty payload
     oc_send_empty_separate_response(&spake_separate_rsp, OC_STATUS_CHANGED);

--- a/api/oc_knx_client.c
+++ b/api/oc_knx_client.c
@@ -84,8 +84,7 @@ update_tokens(uint8_t *secret, int secret_size)
 {
   PRINT("update_tokens: \n");
   oc_oscore_set_auth_mac(oc_string(g_spake_ctx.oscore_id),
-                         oc_byte_string_len(g_spake_ctx.oscore_id),
-                         "", 0,
+                         oc_byte_string_len(g_spake_ctx.oscore_id), "", 0,
                          secret, secret_size);
 }
 
@@ -275,8 +274,8 @@ oc_initiate_spake_parameter_request(oc_endpoint_t *endpoint,
   oc_rep_begin_root_object();
 
   oc_rep_i_set_text_string(root, 0, recipient_id);
-  oc_byte_string_copy_from_char_with_size(&g_spake_ctx.oscore_id,
-                                          recipient_id, recipient_id_len);
+  oc_byte_string_copy_from_char_with_size(&g_spake_ctx.oscore_id, recipient_id,
+                                          recipient_id_len);
 
   oc_rep_i_set_byte_string(root, 15, rnd, 32);
   oc_rep_end_root_object();

--- a/api/oc_knx_client.c
+++ b/api/oc_knx_client.c
@@ -274,7 +274,7 @@ oc_initiate_spake_parameter_request(oc_endpoint_t *endpoint,
     rnd[32]; // not actually used by the server, so just send some gibberish
   oc_rep_begin_root_object();
 
-  oc_rep_i_set_byte_string(root, 0, recipient_id, recipient_id_len);
+  oc_rep_i_set_text_string(root, 0, recipient_id);
   oc_byte_string_copy_from_char_with_size(&g_spake_ctx.oscore_id,
                                           recipient_id, recipient_id_len);
 

--- a/api/oc_knx_client.c
+++ b/api/oc_knx_client.c
@@ -50,7 +50,6 @@ typedef struct oc_spake_context_t
 {
   char spake_password[MAX_PASSWORD_LEN]; /**< spake password */
   oc_string_t serial_number; /**< the serial number of the device string */
-  oc_string_t recipient_id;  /**< the recipient id used (byte string) */
   oc_string_t oscore_id;     /**< the oscore id used (byte string) */
 } oc_spake_context_t;
 
@@ -84,11 +83,10 @@ static void
 update_tokens(uint8_t *secret, int secret_size)
 {
   PRINT("update_tokens: \n");
-  oc_oscore_set_auth_mac(oc_string(g_spake_ctx.serial_number),
-                         oc_string_len(g_spake_ctx.serial_number),
-                         oc_string(g_spake_ctx.recipient_id),
-                         oc_byte_string_len(g_spake_ctx.recipient_id), secret,
-                         secret_size);
+  oc_oscore_set_auth_mac(oc_string(g_spake_ctx.oscore_id),
+                         oc_byte_string_len(g_spake_ctx.oscore_id),
+                         "", 0,
+                         secret, secret_size);
 }
 
 static void
@@ -229,11 +227,6 @@ do_credential_exchange(oc_client_response_t *data)
         inner_rep = inner_rep->next;
       }
     }
-    // oscore context
-    if (rep->type == OC_REP_BYTE_STRING && rep->iname == 0) {
-      strncpy((char *)&g_spake_ctx.oscore_id, oc_string(rep->value.string),
-              MAX_PASSWORD_LEN);
-    }
     rep = rep->next;
   }
 
@@ -282,7 +275,7 @@ oc_initiate_spake_parameter_request(oc_endpoint_t *endpoint,
   oc_rep_begin_root_object();
 
   oc_rep_i_set_byte_string(root, 0, recipient_id, recipient_id_len);
-  oc_byte_string_copy_from_char_with_size(&g_spake_ctx.recipient_id,
+  oc_byte_string_copy_from_char_with_size(&g_spake_ctx.oscore_id,
                                           recipient_id, recipient_id_len);
 
   oc_rep_i_set_byte_string(root, 15, rnd, 32);
@@ -328,9 +321,9 @@ oc_initiate_spake(oc_endpoint_t *endpoint, char *password, char *recipient_id)
   if (recipient_id) {
     // convert from hex string to bytes
     oc_conv_hex_string_to_oc_string(recipient_id, strlen(recipient_id),
-                                    &g_spake_ctx.recipient_id);
-    oc_rep_i_set_byte_string(root, 0, oc_string(g_spake_ctx.recipient_id),
-                             oc_byte_string_len(g_spake_ctx.recipient_id));
+                                    &g_spake_ctx.oscore_id);
+    oc_rep_i_set_byte_string(root, 0, oc_string(g_spake_ctx.oscore_id),
+                             oc_byte_string_len(g_spake_ctx.oscore_id));
     // oc_rep_i_set_byte_string(root, 0, oscore_id, strlen(oscore_id));
     // strncpy((char *)&g_spake_ctx.recipient_id, recipient_id,
     // MAX_PASSWORD_LEN);

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -884,6 +884,11 @@ oc_core_fp_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
             oc_new_string(&g_gpt[index].url, oc_string(object->value.string),
                           oc_string_len(object->value.string));
           }
+          if (object->iname == 14) {
+            oc_free_string(&g_gpt[index].at);
+            oc_new_string(&g_gpt[index].at, oc_string(object->value.string),
+                          oc_string_len(object->value.string));
+          }
         } break;
         case OC_REP_INT_ARRAY: {
           if (object->iname == 7) {
@@ -1023,6 +1028,10 @@ oc_core_fp_p_x_get_handler(oc_request_t *request,
     /* url -10 */
     oc_rep_i_set_text_string(root, 10, oc_string(g_gpt[index].url));
   }
+  // at - 14
+  if (oc_string_len(g_gpt[index].at) > 0) {
+    oc_rep_i_set_text_string(root, 14, oc_string(g_gpt[index].at));
+  }
 
   /* ga -7 */
   oc_rep_i_set_int_array(root, 7, g_gpt[index].ga, g_gpt[index].ga_len);
@@ -1056,6 +1065,8 @@ oc_core_fp_p_x_del_handler(oc_request_t *request,
   g_gpt[index].id = 0;
   oc_free_string(&g_gpt[index].url);
   oc_new_string(&g_gpt[index].url, "", 0);
+  oc_free_string(&g_gpt[index].at);
+  oc_new_string(&g_gpt[index].at, "", 0);
   // oc_free_int_array(g_gpt[index].ga);
   free(g_gpt[index].ga);
   g_gpt[index].ga = NULL;
@@ -1241,6 +1252,11 @@ oc_core_fp_r_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
             oc_new_string(&g_grt[index].url, oc_string(object->value.string),
                           oc_string_len(object->value.string));
           }
+          if (object->iname == 14) {
+            oc_free_string(&g_grt[index].at);
+            oc_new_string(&g_grt[index].at, oc_string(object->value.string),
+                          oc_string_len(object->value.string));
+          }
         } break;
         case OC_REP_INT_ARRAY: {
           if (object->iname == 7) {
@@ -1368,6 +1384,10 @@ oc_core_fp_r_x_get_handler(oc_request_t *request,
   oc_rep_i_set_text_string(root, 112, oc_string(g_grt[index].path));
   // url- 10
   oc_rep_i_set_text_string(root, 10, oc_string(g_grt[index].url));
+  // at - 14
+  if (oc_string_len(g_gpt[index].at) > 0) {
+    oc_rep_i_set_text_string(root, 14, oc_string(g_grt[index].at));
+  }
   // ga - 7
   oc_rep_i_set_int_array(root, 7, g_grt[index].ga, g_grt[index].ga_len);
 
@@ -1402,6 +1422,8 @@ oc_core_fp_r_x_del_handler(oc_request_t *request,
   g_grt[index].id = 0;
   oc_free_string(&g_grt[index].url);
   oc_new_string(&g_grt[index].url, "", 0);
+  oc_free_string(&g_grt[index].at);
+  oc_new_string(&g_grt[index].at, "", 0);
   // oc_free_int_array(g_grt[index].ga);
   free(g_grt[index].ga);
   g_grt[index].ga = NULL;
@@ -1470,6 +1492,7 @@ oc_core_get_recipient_index_url_or_path(int index)
 
     } else {
       // do .knx
+      // spec 1.1. change this to /g
       PRINT("      oc_core_get_recipient_index_url_or_path (default) %s\n",
             ".knx");
       return ".knx";
@@ -1760,6 +1783,9 @@ oc_print_group_rp_table_entry(int entry, char *Store,
   if (oc_string_len(rp_table[entry].url) > 0) {
     PRINT("    url (10)   : '%s'\n", oc_string_checked(rp_table[entry].url));
   }
+  if (oc_string_len(rp_table[entry].at) > 0) {
+    PRINT("    at (14) : %s\n", oc_string_checked(rp_table[entry].at));
+  }
   PRINT("    ga (7)     : [");
   for (int i = 0; i < rp_table[entry].ga_len; i++) {
     PRINT(" %u", rp_table[entry].ga[i]);
@@ -1821,6 +1847,8 @@ oc_dump_group_rp_table_entry(int entry, char *Store,
   oc_rep_i_set_int(root, 25, rp_table[entry].fid);
   // grpid - 13
   oc_rep_i_set_int(root, 13, rp_table[entry].grpid);
+  // at - 14
+  oc_rep_i_set_text_string(root, 14, oc_string(rp_table[entry].at));
   // path- 112
   oc_rep_i_set_text_string(root, 112, oc_string(rp_table[entry].path));
   // url - 10
@@ -1902,6 +1930,11 @@ oc_load_group_rp_table_entry(int entry, char *Store,
             oc_new_string(&rp_table[entry].url, oc_string(rep->value.string),
                           oc_string_len(rep->value.string));
           }
+          if (rep->iname == 14) {
+            oc_free_string(&rp_table[entry].at);
+            oc_new_string(&rp_table[entry].at, oc_string(rep->value.string),
+                          oc_string_len(rep->value.string));
+          }
           break;
         case OC_REP_INT_ARRAY:
           if (rep->iname == 7) {
@@ -1974,6 +2007,7 @@ oc_free_group_rp_table_entry(int entry, char *Store,
   if (init == false) {
     oc_free_string(&rp_table[entry].path);
     oc_free_string(&rp_table[entry].url);
+    oc_free_string(&rp_table[entry].at);
     free(rp_table[entry].ga);
   }
   rp_table[entry].ga = NULL;

--- a/api/oc_knx_fp.h
+++ b/api/oc_knx_fp.h
@@ -181,7 +181,8 @@ typedef struct oc_group_rp_table_t
   uint32_t grpid;   /**< the multicast group id */
   oc_string_t path; /**< contents of path, default path = ".knx"*/
   oc_string_t url;  /**< contents of url */
-  oc_string_t at;   /**< Access token id. Reference to the security credentials for unicast subscription encryption. */
+  oc_string_t at;   /**< Access token id. Reference to the security credentials
+                       for unicast subscription encryption. */
   bool con;         /**< confirmed message, default = false*/
   uint32_t *ga;     /**< array of integers */
   int ga_len;       /**< length of the array of group addresses identifiers */

--- a/api/oc_knx_fp.h
+++ b/api/oc_knx_fp.h
@@ -181,6 +181,7 @@ typedef struct oc_group_rp_table_t
   uint32_t grpid;   /**< the multicast group id */
   oc_string_t path; /**< contents of path, default path = ".knx"*/
   oc_string_t url;  /**< contents of url */
+  oc_string_t at;   /**< Access token id. Reference to the security credentials for unicast subscription encryption. */
   bool con;         /**< confirmed message, default = false*/
   uint32_t *ga;     /**< array of integers */
   int ga_len;       /**< length of the array of group addresses identifiers */

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1531,10 +1531,10 @@ oc_oscore_set_auth_device(char *client_senderid, int client_senderid_size,
   spake_entry.scope = OC_IF_SEC | OC_IF_D | OC_IF_P;
   oc_new_byte_string(&spake_entry.osc_ms, (char *)shared_key, shared_key_size);
   // no context id
-  oc_new_byte_string(&spake_entry.osc_id, client_recipientid,
-                     client_recipientid_size);
-  oc_new_byte_string(&spake_entry.osc_rid, client_senderid,
+  oc_new_byte_string(&spake_entry.osc_id, client_senderid,
                      client_senderid_size);
+  oc_new_byte_string(&spake_entry.osc_rid, client_recipientid,
+                     client_recipientid_size);
 
   int index = oc_core_find_at_entry_with_id(0, client_senderid);
   if (index == -1) {

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1645,20 +1645,19 @@ oc_init_oscore_from_storage(size_t device_index, bool from_storage)
 
         // by default, posts to auth/at set id into the sender id, so the
         // created contexts are only usable for sending. so we must create
-        // contexts for receiving with ids swapped in certain circumstances,
-        // right now for group comms and subsequent tool keys
+        // contexts for receiving with ids swapped
 
-        if (g_at_entries[i].scope & (OC_IF_G | OC_IF_SEC)) {
-          uint64_t ssn = 0;
-          oc_oscore_context_t *ctx = oc_oscore_add_context(
-            device_index, oc_string(g_at_entries[i].osc_rid),
-            oc_byte_string_len(g_at_entries[i].osc_rid),
-            oc_string(g_at_entries[i].osc_id),
-            oc_byte_string_len(g_at_entries[i].osc_id), ssn, "desc",
-            oc_string(g_at_entries[i].osc_ms),
-            oc_byte_string_len(g_at_entries[i].osc_ms),
-            oc_string(g_at_entries[i].osc_contextid),
-            oc_byte_string_len(g_at_entries[i].osc_contextid), i, from_storage);
+        ctx = oc_oscore_add_context(
+          device_index, oc_string(g_at_entries[i].osc_rid),
+          oc_byte_string_len(g_at_entries[i].osc_rid),
+          oc_string(g_at_entries[i].osc_id),
+          oc_byte_string_len(g_at_entries[i].osc_id), ssn, "desc",
+          oc_string(g_at_entries[i].osc_ms),
+          oc_byte_string_len(g_at_entries[i].osc_ms),
+          oc_string(g_at_entries[i].osc_contextid),
+          oc_byte_string_len(g_at_entries[i].osc_contextid), i, from_storage);
+        if (ctx == NULL) {
+          OC_ERR("  failed to load index= %d", i);
         }
       } else {
         OC_DBG_OSCORE("oc_init_oscore: no oscore context");

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1472,14 +1472,14 @@ oc_reset_at_table(size_t device_index, int erase_code)
 // ----------------------------------------------------------------------------
 
 void
-oc_oscore_set_auth_mac(char *serial_number, int serial_number_size,
+oc_oscore_set_auth_mac(char *client_senderid, int client_senderid_size,
                        char *client_recipientid, int client_recipientid_size,
                        uint8_t *shared_key, int shared_key_size)
 {
   // create the token & store in at tables at position 0
   // note there should be no entries.. if there is an entry then overwrite
   // it..
-  PRINT("oc_oscore_set_auth_mac sn       : %s\n", serial_number);
+  PRINT("oc_oscore_set_auth_mac sn       : %s\n", client_senderid);
   PRINT("oc_oscore_set_auth_mac rid [%d] : ", client_recipientid_size);
   oc_char_println_hex(client_recipientid, client_recipientid_size);
   PRINT("oc_oscore_set_auth_mac ms  [%d] : ", shared_key_size);
@@ -1488,7 +1488,7 @@ oc_oscore_set_auth_mac(char *serial_number, int serial_number_size,
   oc_auth_at_t spake_entry;
   memset(&spake_entry, 0, sizeof(spake_entry));
   // this is the index in the table, so it is the full string
-  oc_new_string(&spake_entry.id, serial_number, serial_number_size);
+  oc_new_string(&spake_entry.id, client_senderid, client_senderid_size);
   spake_entry.ga_len = 0;
   spake_entry.profile = OC_PROFILE_COAP_OSCORE;
   spake_entry.scope = OC_IF_SEC | OC_IF_D | OC_IF_P;
@@ -1498,13 +1498,10 @@ oc_oscore_set_auth_mac(char *serial_number, int serial_number_size,
                      client_recipientid_size);
   // not that HEX was NOT on the wire, but the byte string.
   // so we have to store the byte string
-  oc_conv_hex_string_to_oc_string(serial_number, serial_number_size,
-                                  &spake_entry.osc_id);
+  oc_new_byte_string(&spake_entry.osc_id, client_senderid,
+                     client_senderid_size);
 
-  PRINT("oc_oscore_set_auth_mac osc_id (hex) from serial number: ");
-  oc_string_println_hex(spake_entry.osc_id);
-
-  int index = oc_core_find_at_entry_with_id(0, serial_number);
+  int index = oc_core_find_at_entry_with_id(0, client_senderid);
   if (index == -1) {
     index = oc_core_find_at_entry_empty_slot(0);
   }
@@ -1521,14 +1518,13 @@ oc_oscore_set_auth_mac(char *serial_number, int serial_number_size,
 // This looks very similar to oc_oscore_set_auth_mac, but has some very
 // particular differences. The key identifier is the same as before (serial
 // number), but the sender & receiver IDs are swapped. Here, the sender ID is
-// client_recipientid, referring to the MAC. And the receiver ID is the serial
-// number.
+// client_recipientid, referring to the MAC. And the receiver ID is emtpy string
 void
-oc_oscore_set_auth_device(char *serial_number, int serial_number_size,
+oc_oscore_set_auth_device(char *client_senderid, int client_senderid_size,
                           char *client_recipientid, int client_recipientid_size,
                           uint8_t *shared_key, int shared_key_size)
 {
-  PRINT("oc_oscore_set_auth_device sn :%s\n", serial_number);
+  PRINT("oc_oscore_set_auth_device sn :%s\n", client_senderid);
   PRINT("oc_oscore_set_auth_device rid : (%d) ", client_recipientid_size);
   oc_char_println_hex(client_recipientid, client_recipientid_size);
   PRINT("oc_oscore_set_auth_device ms : (%d) ", shared_key_size);
@@ -1537,7 +1533,7 @@ oc_oscore_set_auth_device(char *serial_number, int serial_number_size,
   oc_auth_at_t spake_entry;
   memset(&spake_entry, 0, sizeof(spake_entry));
   // this is the index in the table, so it is the full string
-  oc_new_string(&spake_entry.id, serial_number, serial_number_size);
+  oc_new_string(&spake_entry.id, client_senderid, client_senderid_size);
   spake_entry.ga_len = 0;
   spake_entry.profile = OC_PROFILE_COAP_OSCORE;
   spake_entry.scope = OC_IF_SEC | OC_IF_D | OC_IF_P;
@@ -1545,13 +1541,10 @@ oc_oscore_set_auth_device(char *serial_number, int serial_number_size,
   // no context id
   oc_new_byte_string(&spake_entry.osc_id, client_recipientid,
                      client_recipientid_size);
-  oc_conv_hex_string_to_oc_string(serial_number, serial_number_size,
-                                  &spake_entry.osc_rid);
+  oc_new_byte_string(&spake_entry.osc_rid, client_senderid,
+                     client_senderid_size);
 
-  PRINT("  osc_id (hex) from serial number: ");
-  oc_string_println_hex(spake_entry.osc_id);
-
-  int index = oc_core_find_at_entry_with_id(0, serial_number);
+  int index = oc_core_find_at_entry_with_id(0, client_senderid);
   if (index == -1) {
     index = oc_core_find_at_entry_empty_slot(0);
   }

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1626,7 +1626,6 @@ oc_init_oscore_from_storage(size_t device_index, bool from_storage)
 
       if (g_at_entries[i].profile == OC_PROFILE_COAP_OSCORE) {
         uint64_t ssn = 0;
-        // one context: for sending and receiving.
         oc_oscore_context_t *ctx = oc_oscore_add_context(
           device_index, oc_string(g_at_entries[i].osc_id),
           oc_byte_string_len(g_at_entries[i].osc_id),
@@ -1638,6 +1637,30 @@ oc_init_oscore_from_storage(size_t device_index, bool from_storage)
           oc_byte_string_len(g_at_entries[i].osc_contextid), i, from_storage);
         if (ctx == NULL) {
           OC_ERR("  failed to load index= %d", i);
+        }
+
+        // contexts for sending have populated sender id and null receive id
+        // the spake key, however, is for receiving only, and the osc_id is
+        // already inside receiver_id. 
+
+        // by default, posts to auth/at set id into the sender id, so the created
+        // contexts are only usable for sending. so we must create contexts for receiving
+        // with ids swapped in certain circumstances, right now for group comms and
+        // subsequent tool keys
+
+        if (g_at_entries[i].scope & (OC_IF_G | OC_IF_SEC)) {
+          uint64_t ssn = 0;
+          oc_oscore_context_t *ctx = oc_oscore_add_context(
+            device_index,
+            oc_string(g_at_entries[i].osc_rid),
+            oc_byte_string_len(g_at_entries[i].osc_rid),
+            oc_string(g_at_entries[i].osc_id),
+            oc_byte_string_len(g_at_entries[i].osc_id),
+            ssn, "desc",
+            oc_string(g_at_entries[i].osc_ms),
+            oc_byte_string_len(g_at_entries[i].osc_ms),
+            oc_string(g_at_entries[i].osc_contextid),
+            oc_byte_string_len(g_at_entries[i].osc_contextid), i, from_storage);
         }
       } else {
         OC_DBG_OSCORE("oc_init_oscore: no oscore context");

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -52,6 +52,12 @@ oc_string_to_at_profile(oc_string_t str)
   if (strcmp(oc_string(str), "coap_dtls") == 0) {
     return OC_PROFILE_COAP_DTLS;
   }
+  if (strcmp(oc_string(str), "coap_tls") == 0) {
+    return OC_PROFILE_COAP_TLS;
+  }
+  if (strcmp(oc_string(str), "coap_pase") == 0) {
+    return OC_PROFILE_COAP_PASE;
+  }
   return OC_PROFILE_UNKNOWN;
 }
 
@@ -63,6 +69,12 @@ oc_at_profile_to_string(oc_at_profile_t at_profile)
   }
   if (at_profile == OC_PROFILE_COAP_DTLS) {
     return "coap_dtls";
+  }
+  if (at_profile == OC_PROFILE_COAP_TLS) {
+    return "coap_tls";
+  }
+  if (at_profile == OC_PROFILE_COAP_PASE) {
+    return "coap_pase";
   }
   return "";
 }
@@ -603,13 +615,13 @@ oc_core_auth_at_post_handler(oc_request_t *request,
                           oc_string(object->value.string),
                           oc_string_len(object->value.string));
           }
-          if (object->iname == 3) {
+          //if (object->iname == 3) {
             // aud
-            oc_free_string(&(g_at_entries[index].aud));
-            oc_new_string(&g_at_entries[index].aud,
-                          oc_string(object->value.string),
-                          oc_string_len(object->value.string));
-          }
+          //  oc_free_string(&(g_at_entries[index].aud));
+          //  oc_new_string(&g_at_entries[index].aud,
+          //                oc_string(object->value.string),
+          //                oc_string_len(object->value.string));
+          //}
         } else if (object->type == OC_REP_INT) {
           if (object->iname == 38) {
             // profile (38 ("coap_dtls" ==1 or "coap_oscore" == 2))
@@ -827,9 +839,9 @@ oc_core_auth_at_x_get_handler(oc_request_t *request,
   // id : 0
   oc_rep_i_set_text_string(root, 0, oc_string(g_at_entries[index].id));
   // audience : 3
-  if (oc_string_len(g_at_entries[index].aud) > 0) {
-    oc_rep_i_set_text_string(root, 3, oc_string(g_at_entries[index].aud));
-  }
+  //if (oc_string_len(g_at_entries[index].aud) > 0) {
+  //  oc_rep_i_set_text_string(root, 3, oc_string(g_at_entries[index].aud));
+  //}
   // the scope as list of cflags or group object table entries
   int nr_entries = oc_total_interface_in_mask(g_at_entries[index].scope);
   if (nr_entries > 0) {

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1493,7 +1493,7 @@ oc_oscore_set_auth_mac(char *client_senderid, int client_senderid_size,
   oc_new_byte_string(&spake_entry.osc_id, client_senderid,
                      client_senderid_size);
 
-  int index = oc_core_find_at_entry_with_id(0, client_senderid);
+  int index = oc_core_find_at_entry_with_id(0, oc_string(spake_entry.id));
   if (index == -1) {
     index = oc_core_find_at_entry_empty_slot(0);
   }
@@ -1536,7 +1536,7 @@ oc_oscore_set_auth_device(char *client_senderid, int client_senderid_size,
   oc_new_byte_string(&spake_entry.osc_rid, client_recipientid,
                      client_recipientid_size);
 
-  int index = oc_core_find_at_entry_with_id(0, client_senderid);
+  int index = oc_core_find_at_entry_with_id(0, oc_string(spake_entry.id));
   if (index == -1) {
     index = oc_core_find_at_entry_empty_slot(0);
   }

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -615,8 +615,8 @@ oc_core_auth_at_post_handler(oc_request_t *request,
                           oc_string(object->value.string),
                           oc_string_len(object->value.string));
           }
-          //if (object->iname == 3) {
-            // aud
+          // if (object->iname == 3) {
+          //  aud
           //  oc_free_string(&(g_at_entries[index].aud));
           //  oc_new_string(&g_at_entries[index].aud,
           //                oc_string(object->value.string),
@@ -819,7 +819,7 @@ oc_core_auth_at_x_get_handler(oc_request_t *request,
   // id : 0
   oc_rep_i_set_text_string(root, 0, oc_string(g_at_entries[index].id));
   // audience : 3
-  //if (oc_string_len(g_at_entries[index].aud) > 0) {
+  // if (oc_string_len(g_at_entries[index].aud) > 0) {
   //  oc_rep_i_set_text_string(root, 3, oc_string(g_at_entries[index].aud));
   //}
   // the scope as list of cflags or group object table entries
@@ -1641,22 +1641,20 @@ oc_init_oscore_from_storage(size_t device_index, bool from_storage)
 
         // contexts for sending have populated sender id and null receive id
         // the spake key, however, is for receiving only, and the osc_id is
-        // already inside receiver_id. 
+        // already inside receiver_id.
 
-        // by default, posts to auth/at set id into the sender id, so the created
-        // contexts are only usable for sending. so we must create contexts for receiving
-        // with ids swapped in certain circumstances, right now for group comms and
-        // subsequent tool keys
+        // by default, posts to auth/at set id into the sender id, so the
+        // created contexts are only usable for sending. so we must create
+        // contexts for receiving with ids swapped in certain circumstances,
+        // right now for group comms and subsequent tool keys
 
         if (g_at_entries[i].scope & (OC_IF_G | OC_IF_SEC)) {
           uint64_t ssn = 0;
           oc_oscore_context_t *ctx = oc_oscore_add_context(
-            device_index,
-            oc_string(g_at_entries[i].osc_rid),
+            device_index, oc_string(g_at_entries[i].osc_rid),
             oc_byte_string_len(g_at_entries[i].osc_rid),
             oc_string(g_at_entries[i].osc_id),
-            oc_byte_string_len(g_at_entries[i].osc_id),
-            ssn, "desc",
+            oc_byte_string_len(g_at_entries[i].osc_id), ssn, "desc",
             oc_string(g_at_entries[i].osc_ms),
             oc_byte_string_len(g_at_entries[i].osc_ms),
             oc_string(g_at_entries[i].osc_contextid),

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -678,15 +678,15 @@ oc_core_auth_at_post_handler(oc_request_t *request,
                                        oc_string_len(oscobject->value.string));
                     other_updated = true;
                   }
-                  if (oscobject->iname == 7 && subobject_nr == 8 &&
-                      oscobject_nr == 4) {
-                    // cnf::osc::rid
-                    oc_free_string(&(g_at_entries[index].osc_rid));
-                    oc_new_byte_string(&g_at_entries[index].osc_rid,
-                                       oc_string(oscobject->value.string),
-                                       oc_string_len(oscobject->value.string));
-                    other_updated = true;
-                  }
+                  // if (oscobject->iname == 7 && subobject_nr == 8 &&
+                  //     oscobject_nr == 4) {
+                  //   // cnf::osc::rid
+                  //   oc_free_string(&(g_at_entries[index].osc_rid));
+                  //   oc_new_byte_string(&g_at_entries[index].osc_rid,
+                  //                      oc_string(oscobject->value.string),
+                  //                      oc_string_len(oscobject->value.string));
+                  //   other_updated = true;
+                  // }
                   if (oscobject->iname == 0 && subobject_nr == 8 &&
                       oscobject_nr == 4) {
                     // cnf::osc::id
@@ -708,26 +708,6 @@ oc_core_auth_at_post_handler(oc_request_t *request,
       } // while (inner object)
     }   // if type == object
     // show the entry on screen
-    //
-    // temp backward compatibility fix: if recipient id is not there then use
-    // SID for recipient ID
-    if (oc_string_len(g_at_entries[index].osc_rid) == 0) {
-      oc_free_string(&(g_at_entries[index].osc_rid));
-      oc_new_byte_string(&g_at_entries[index].osc_rid,
-                         oc_string(g_at_entries[index].osc_id),
-                         oc_byte_string_len(g_at_entries[index].osc_id));
-    }
-    // temp backward compatibility fix: if context id is not there then use
-    // SID for context ID
-    /*
-    if (oc_string_len(g_at_entries[index].osc_contextid) == 0) {
-      oc_free_string(&(g_at_entries[index].osc_contextid));
-      oc_new_byte_string(&g_at_entries[index].osc_contextid,
-                         oc_string(g_at_entries[index].osc_id),
-                         oc_byte_string_len(g_at_entries[index].osc_id));
-    }
-    */
-
     oc_print_auth_at_entry(device_index, index);
 
     // dump the entry to persistent storage
@@ -892,12 +872,12 @@ oc_core_auth_at_x_get_handler(oc_request_t *request,
         oc_byte_string_len(
           g_at_entries[index].osc_contextid)); // root::cnf::osc::contextid
     }
-    if (oc_string_len(g_at_entries[index].osc_rid) > 0) {
-      oc_rep_i_set_byte_string(
-        osc, 7, oc_string(g_at_entries[index].osc_rid),
-        oc_byte_string_len(
-          g_at_entries[index].osc_rid)); // root::cnf::osc::osc_rid
-    }
+    // if (oc_string_len(g_at_entries[index].osc_rid) > 0) {
+    //   oc_rep_i_set_byte_string(
+    //     osc, 7, oc_string(g_at_entries[index].osc_rid),
+    //     oc_byte_string_len(
+    //       g_at_entries[index].osc_rid)); // root::cnf::osc::osc_rid
+    // }
     if (oc_string_len(g_at_entries[index].osc_id) > 0) {
       oc_rep_i_set_byte_string(
         osc, 0, oc_string(g_at_entries[index].osc_id),

--- a/api/oc_knx_sec.h
+++ b/api/oc_knx_sec.h
@@ -233,18 +233,18 @@ int oc_core_find_at_entry_empty_slot(size_t device_index);
  * @brief set shared (SPAKE) key to the auth at table, on the Management Client
  * side
  *
- * @param serial_number the serial_number of the device that has been negotiated
+ * @param client_senderid the client_senderid of the device that has been negotiated
  * with spake2plus. This will become the Receiver ID within the OSCORE context.
  * This value is an ASCII-encoded string representing the hexadecimal serial
  * number
- * @param serial_number_size the size of the serial number
+ * @param client_senderid_size the size of the serial number
  * @param clientrecipient_id the clientrecipient_id (delivered during the
  * handshake). This will become the Sender ID. This value is in HEX
  * @param clientrecipient_id_size the size of the clientrecipient_id
  * @param shared_key the master key after SPAKE2 handshake
  * @param shared_key_size the key size
  */
-void oc_oscore_set_auth_mac(char *serial_number, int serial_number_size,
+void oc_oscore_set_auth_mac(char *client_senderid, int client_senderid_size,
                             char *clientrecipient_id,
                             int clientrecipient_id_size, uint8_t *shared_key,
                             int shared_key_size);
@@ -252,18 +252,18 @@ void oc_oscore_set_auth_mac(char *serial_number, int serial_number_size,
 /**
  * @brief set shared (SPAKE) key to the auth at table, on the Device side
  *
- * @param serial_number the serial_number of the device that has been negotiated
+ * @param client_senderid the client_senderid of the device that has been negotiated
  * with spake2plus. This will become the Sender ID within the OSCORE context.
  * This value is an ASCII-encoded string representing the hexadecimal serial
  * number
- * @param serial_number_size the size of the serial number
+ * @param client_senderid_size the size of the serial number
  * @param clientrecipient_id the clientrecipient_id (delivered during the
  * handshake). This will become the Receiver ID. This value is in HEX
  * @param clientrecipient_id_size the size of the clientrecipient_id
  * @param shared_key the master key after SPAKE2 handshake
  * @param shared_key_size the key size
  */
-void oc_oscore_set_auth_device(char *serial_number, int serial_number_size,
+void oc_oscore_set_auth_device(char *client_senderid, int client_senderid_size,
                                char *clientrecipient_id,
                                int clientrecipient_id_size, uint8_t *shared_key,
                                int shared_key_size);

--- a/api/oc_knx_sec.h
+++ b/api/oc_knx_sec.h
@@ -67,11 +67,12 @@ extern "C" {
  * see section 3.5.4.2 Access Token Resource Object
  */
 typedef enum {
-  OC_PROFILE_UNKNOWN = 0,      /**< unknown profile */
-  OC_PROFILE_COAP_DTLS = 1,    /**< "coap_dtls" */
-  OC_PROFILE_COAP_OSCORE = 2,  /**< "coap_oscore" */
-  OC_PROFILE_COAP_TLS = 254,   /**< coap_tls" [OSCORE] for [X.509] certificates with TLS */
-  OC_PROFILE_COAP_PASE = 255   /**< "coap_pase" [OSCORE] with PASE credentials */
+  OC_PROFILE_UNKNOWN = 0,     /**< unknown profile */
+  OC_PROFILE_COAP_DTLS = 1,   /**< "coap_dtls" */
+  OC_PROFILE_COAP_OSCORE = 2, /**< "coap_oscore" */
+  OC_PROFILE_COAP_TLS =
+    254, /**< coap_tls" [OSCORE] for [X.509] certificates with TLS */
+  OC_PROFILE_COAP_PASE = 255 /**< "coap_pase" [OSCORE] with PASE credentials */
 } oc_at_profile_t;
 
 /**
@@ -178,7 +179,8 @@ typedef struct oc_auth_at_t
   oc_string_t
     osc_salt; /**< (18:4:5) OSCORE cnf:osc:salt (optional) empty string */
   oc_string_t osc_contextid;
-  /**< (18:4:6) OSCORE cnf:osc:contextid used as "kid_context" (byte string, 6 bytes) */
+  /**< (18:4:6) OSCORE cnf:osc:contextid used as "kid_context" (byte string, 6
+   * bytes) */
   oc_string_t osc_id; /**< (18:4:0) OSCORE cnf:osc:id  (used as SID & KID) (byte
                          string), max 7 bytes */
   oc_string_t
@@ -233,10 +235,10 @@ int oc_core_find_at_entry_empty_slot(size_t device_index);
  * @brief set shared (SPAKE) key to the auth at table, on the Management Client
  * side
  *
- * @param client_senderid the client_senderid of the device that has been negotiated
- * with spake2plus. This will become the Receiver ID within the OSCORE context.
- * This value is an ASCII-encoded string representing the hexadecimal serial
- * number
+ * @param client_senderid the client_senderid of the device that has been
+ * negotiated with spake2plus. This will become the Receiver ID within the
+ * OSCORE context. This value is an ASCII-encoded string representing the
+ * hexadecimal serial number
  * @param client_senderid_size the size of the serial number
  * @param clientrecipient_id the clientrecipient_id (delivered during the
  * handshake). This will become the Sender ID. This value is in HEX
@@ -252,10 +254,10 @@ void oc_oscore_set_auth_mac(char *client_senderid, int client_senderid_size,
 /**
  * @brief set shared (SPAKE) key to the auth at table, on the Device side
  *
- * @param client_senderid the client_senderid of the device that has been negotiated
- * with spake2plus. This will become the Sender ID within the OSCORE context.
- * This value is an ASCII-encoded string representing the hexadecimal serial
- * number
+ * @param client_senderid the client_senderid of the device that has been
+ * negotiated with spake2plus. This will become the Sender ID within the OSCORE
+ * context. This value is an ASCII-encoded string representing the hexadecimal
+ * serial number
  * @param client_senderid_size the size of the serial number
  * @param clientrecipient_id the clientrecipient_id (delivered during the
  * handshake). This will become the Receiver ID. This value is in HEX

--- a/apps/simpleclient_spake_all.c
+++ b/apps/simpleclient_spake_all.c
@@ -164,6 +164,11 @@ callback(oc_client_response_t *rsp)
 oc_event_callback_retval_t
 do_pm(void *ep)
 {
+  if (oc_endpoint_set_oscore_id(ep, "rcpids", strlen("rcpids")) != 0) {
+    // PRINT(
+    //   "  \n");
+    // return;
+  }
   oc_endpoint_t *endpoint = ep;
   endpoint->flags |= SECURED | OSCORE;
   oc_do_get("/dev/pm", endpoint, NULL, callback, HIGH_QOS, NULL);
@@ -214,13 +219,8 @@ discovery(const char *payload, int len, oc_endpoint_t *endpoint,
   // memcpy(&the_endpoint.oscore_id, sernum, 6);
   // the_endpoint.oscore_id_len = 6;
 
-  if (oc_endpoint_set_oscore_id_from_str(&the_endpoint, "00fa10010701") != 0) {
-    // PRINT(
-    //   "  \n");
-    // return;
-  }
   // do parameter exchange
-  oc_initiate_spake_parameter_request(endpoint, "00FA10010701", "LETTUCE",
+  oc_initiate_spake_parameter_request(endpoint, "00fa10010701", "LETTUCE",
                                       "rcpids", strlen("rcpids"));
 
   oc_set_delayed_callback(&the_endpoint, do_pm, 10);

--- a/security/oc_oscore.h
+++ b/security/oc_oscore.h
@@ -28,6 +28,9 @@ extern "C" {
 
 OC_PROCESS_NAME(oc_oscore_handler);
 
+void oc_oscore_set_next_ssn(uint64_t ssn);
+uint64_t oc_oscore_get_next_ssn();
+
 #ifdef __cplusplus
 }
 #endif

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -41,6 +41,9 @@ oc_oscore_find_context_by_kid(oc_oscore_context_t *ctx, size_t device_index,
     ctx = (oc_oscore_context_t *)oc_list_head(contexts);
   }
 
+  if (kid_len == 0)
+    return NULL;
+
   PRINT("oc_oscore_find_context_by_kid : dev=%d  kid:(%d) :", (int)device_index,
         kid_len);
   oc_char_println_hex((char *)(kid), kid_len);
@@ -115,8 +118,7 @@ oc_oscore_find_context_by_token_mid(size_t device, uint8_t *token,
     //      ctx->device == device) {
     //    return ctx;
     //   }
-    char *ctx_serial_number = ctx->token_id;
-    if (memcmp(oscore_id, ctx_serial_number, oscore_id_len) == 0) {
+    if (memcmp(oscore_id, ctx->sendid , oscore_id_len) == 0) {
       PRINT("oc_oscore_find_context_by_token_mid FOUND auth/at index: %d\n",
             ctx->auth_at_index);
       return ctx;

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -118,7 +118,7 @@ oc_oscore_find_context_by_token_mid(size_t device, uint8_t *token,
     //      ctx->device == device) {
     //    return ctx;
     //   }
-    if (memcmp(oscore_id, ctx->sendid , oscore_id_len) == 0) {
+    if (memcmp(oscore_id, ctx->sendid, oscore_id_len) == 0) {
       PRINT("oc_oscore_find_context_by_token_mid FOUND auth/at index: %d\n",
             ctx->auth_at_index);
       return ctx;

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -336,9 +336,6 @@ oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
     // explicit token
     memcpy(ctx->token_id, senderid, senderid_size);
     ctx->sendid_len = (uint8_t)senderid_size;
-  } else {
-    OC_ERR("senderid == NULL");
-    goto add_oscore_context_error;
   }
   PRINT("SendID (%d):", ctx->sendid_len);
   OC_LOGbytes_OSCORE(ctx->sendid, ctx->sendid_len);
@@ -352,9 +349,6 @@ oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
     // }
     memcpy(ctx->recvid, recipientid, recipientid_size);
     ctx->recvid_len = (uint8_t)recipientid_size;
-  } else {
-    OC_ERR("recipientid == NULL");
-    goto add_oscore_context_error;
   }
   PRINT("RecvID (%d):", ctx->recvid_len);
   OC_LOGbytes_OSCORE(ctx->recvid, ctx->recvid_len);

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -36,6 +36,18 @@
 
 OC_PROCESS(oc_oscore_handler, "OSCORE Process");
 
+static bool g_ssn_in_use = false;
+static uint64_t g_ssn = 0;
+
+void oc_oscore_set_next_ssn(uint64_t ssn) {
+  g_ssn = ssn;
+  g_ssn_in_use = true;
+}
+
+uint64_t oc_oscore_get_next_ssn() {
+  return g_ssn;
+}
+
 static void
 increment_ssn_in_context(oc_oscore_context_t *ctx)
 {
@@ -424,6 +436,13 @@ oc_oscore_send_multicast_message(oc_message_t *message)
                                  AAD[OSCORE_AAD_MAX_LEN], AAD_len = 0;
 
     OC_DBG_OSCORE("### protecting multicast request ###");
+
+    if (g_ssn_in_use)
+    {
+      oscore_ctx->ssn = g_ssn;
+      g_ssn_in_use = false;
+    }
+
     /* Use context->SSN as Partial IV */
     oscore_store_piv(oscore_ctx->ssn, piv, &piv_len);
     // OC_DBG_OSCORE("---using SSN as Partial IV: %lu", oscore_ctx->ssn);
@@ -685,6 +704,11 @@ oc_oscore_send_message(oc_message_t *msg)
     ) {
 
       OC_DBG_OSCORE("### protecting outgoing request ###");
+      if (g_ssn_in_use)
+      {
+        oscore_ctx->ssn = g_ssn;
+        g_ssn_in_use = false;
+      }
       /* Request */
       /* Use context->SSN as Partial IV */
       oscore_store_piv(oscore_ctx->ssn, piv, &piv_len);

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -777,7 +777,7 @@ oc_oscore_send_message(oc_message_t *msg)
         goto oscore_send_dispatch;
       }
       OC_DBG("### protecting outgoing response ###");
-      
+
       // TODO: reuse request AEAD nonce instead of sending new SSN
 
       /* Response */

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -39,12 +39,16 @@ OC_PROCESS(oc_oscore_handler, "OSCORE Process");
 static bool g_ssn_in_use = false;
 static uint64_t g_ssn = 0;
 
-void oc_oscore_set_next_ssn(uint64_t ssn) {
+void
+oc_oscore_set_next_ssn(uint64_t ssn)
+{
   g_ssn = ssn;
   g_ssn_in_use = true;
 }
 
-uint64_t oc_oscore_get_next_ssn() {
+uint64_t
+oc_oscore_get_next_ssn()
+{
   return g_ssn;
 }
 
@@ -437,8 +441,7 @@ oc_oscore_send_multicast_message(oc_message_t *message)
 
     OC_DBG_OSCORE("### protecting multicast request ###");
 
-    if (g_ssn_in_use)
-    {
+    if (g_ssn_in_use) {
       oscore_ctx->ssn = g_ssn;
       g_ssn_in_use = false;
     }
@@ -704,8 +707,7 @@ oc_oscore_send_message(oc_message_t *msg)
     ) {
 
       OC_DBG_OSCORE("### protecting outgoing request ###");
-      if (g_ssn_in_use)
-      {
+      if (g_ssn_in_use) {
         oscore_ctx->ssn = g_ssn;
         g_ssn_in_use = false;
       }

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -616,8 +616,8 @@ oc_oscore_send_message(oc_message_t *msg)
   if (entry) {
     OC_DBG_OSCORE("### Found auth at entry, getting context ###");
     oscore_ctx = oc_oscore_find_context_by_kid(
-      NULL, message->endpoint.device, oc_string(entry->osc_rid),
-      oc_byte_string_len(entry->osc_rid));
+      NULL, message->endpoint.device, oc_string(entry->osc_id),
+      oc_byte_string_len(entry->osc_id));
   }
   // Search for OSCORE context using addressing information
 
@@ -777,6 +777,9 @@ oc_oscore_send_message(oc_message_t *msg)
         goto oscore_send_dispatch;
       }
       OC_DBG("### protecting outgoing response ###");
+      
+      // TODO: reuse request AEAD nonce instead of sending new SSN
+
       /* Response */
       /* Per specification, all responses must include a new Partial IV */
       /* Use context->SSN as partial IV */


### PR DESCRIPTION
- get rid of receiver id in auth/at entry handlers
- get rid of serial number use in oscore ids
- add at field to publisher and recipient table
- make ID field in spake handlers text string instead of byte string