### PR TITLE
Fix handler contexts for S-Mode messages

### DIFF
--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -849,7 +849,7 @@ oc_core_knx_knx_post_handler(oc_request_t *request,
         // if (my_resource->post_handler.cb) {
         //  my_resource->post_handler.cb(&new_request, iface_mask, data);
         if (my_resource->put_handler.cb) {
-          my_resource->put_handler.cb(&new_request, iface_mask, 
+          my_resource->put_handler.cb(&new_request, iface_mask,
                                       my_resource->put_handler.user_data);
           if ((cflags & OC_CFLAG_TRANSMISSION) > 0) {
             // Case 3) part 1
@@ -870,8 +870,8 @@ oc_core_knx_knx_post_handler(oc_request_t *request,
         // Received from bus: -st rp , any ga
         // @receiver : cflags = u->overwrite object value
         if (my_resource->post_handler.cb) {
-          my_resource->post_handler.cb(&new_request, iface_mask, 
-                                      my_resource->post_handler.user_data);
+          my_resource->post_handler.cb(&new_request, iface_mask,
+                                       my_resource->post_handler.user_data);
           if ((cflags & OC_CFLAG_TRANSMISSION) > 0) {
             PRINT(
               "   (case3) (RP-UPDATE) sending WRITE due to TRANSMIT flag \n");

--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -849,7 +849,8 @@ oc_core_knx_knx_post_handler(oc_request_t *request,
         // if (my_resource->post_handler.cb) {
         //  my_resource->post_handler.cb(&new_request, iface_mask, data);
         if (my_resource->put_handler.cb) {
-          my_resource->put_handler.cb(&new_request, iface_mask, data);
+          my_resource->put_handler.cb(&new_request, iface_mask, 
+                                      my_resource->put_handler.user_data);
           if ((cflags & OC_CFLAG_TRANSMISSION) > 0) {
             // Case 3) part 1
             // @sender : updated object value + cflags = t
@@ -869,7 +870,8 @@ oc_core_knx_knx_post_handler(oc_request_t *request,
         // Received from bus: -st rp , any ga
         // @receiver : cflags = u->overwrite object value
         if (my_resource->post_handler.cb) {
-          my_resource->post_handler.cb(&new_request, iface_mask, data);
+          my_resource->post_handler.cb(&new_request, iface_mask, 
+                                      my_resource->post_handler.user_data);
           if ((cflags & OC_CFLAG_TRANSMISSION) > 0) {
             PRINT(
               "   (case3) (RP-UPDATE) sending WRITE due to TRANSMIT flag \n");

--- a/api/oc_knx_client.c
+++ b/api/oc_knx_client.c
@@ -637,7 +637,7 @@ oc_s_mode_get_resource_value(char *resource_url, char *rp, uint8_t *buf,
   // get the value...oc_request_t request_obj;
   oc_interface_mask_t iface_mask = OC_IF_NONE;
   // void *data;
-  my_resource->get_handler.cb(&request, iface_mask, NULL);
+  my_resource->get_handler.cb(&request, iface_mask, my_resource->get_handler.user_data);
 
   // get the data
   int value_size = oc_rep_get_encoded_payload_size();

--- a/api/oc_knx_client.c
+++ b/api/oc_knx_client.c
@@ -637,7 +637,8 @@ oc_s_mode_get_resource_value(char *resource_url, char *rp, uint8_t *buf,
   // get the value...oc_request_t request_obj;
   oc_interface_mask_t iface_mask = OC_IF_NONE;
   // void *data;
-  my_resource->get_handler.cb(&request, iface_mask, my_resource->get_handler.user_data);
+  my_resource->get_handler.cb(&request, iface_mask,
+                              my_resource->get_handler.user_data);
 
   // get the data
   int value_size = oc_rep_get_encoded_payload_size();


### PR DESCRIPTION
S-mode messages should use handler user-data specified, rather than fixed NULL or inherited from `/.knx` handler.