### PR TITLE
Implement replay protection for NON frames

### DIFF
--- a/api/oc_buffer.c
+++ b/api/oc_buffer.c
@@ -77,20 +77,17 @@ allocate_message(struct oc_memb *pool)
     OC_DBG("buffer: Allocated TX/RX buffer; num free: %d",
            oc_memb_numfree(pool));
 #endif /* !OC_DYNAMIC_ALLOCATION || OC_INOUT_BUFFER_SIZE */
-  }
-  else {
+  } else {
     // no unused buffers, so go through buffers with soft references and
     // free one. said buffer can no longer be used for e.g. retransmitting
     // requests when challenged with an Echo option. however, freeing up
     // one of these means that it can no longer be used for its original
     // purpose
-    for (int i = 0; i < pool->num; ++i)
-    {
+    for (int i = 0; i < pool->num; ++i) {
       int offset = pool->size * i;
-      message = (oc_message_t*) ((uint8_t*)pool->mem + offset);
+      message = (oc_message_t *)((uint8_t *)pool->mem + offset);
 
-      if (message->ref_count == 1 && message->soft_ref_cb != NULL)
-      {
+      if (message->ref_count == 1 && message->soft_ref_cb != NULL) {
         OC_WRN("Freeing echo retransmission candidate %p");
         message->soft_ref_cb(message);
         // we know that was the last reference, so now we can allocate
@@ -176,16 +173,16 @@ oc_send_message(oc_message_t *message)
   // point we only have the encoded CoAP bytes, so we parse just the header
   // and token.
   uint8_t version = (COAP_HEADER_VERSION_MASK & message->data[0]) >>
-                      COAP_HEADER_VERSION_POSITION;
+                    COAP_HEADER_VERSION_POSITION;
   uint8_t type =
     (COAP_HEADER_TYPE_MASK & message->data[0]) >> COAP_HEADER_TYPE_POSITION;
   uint8_t code = message->data[1];
   uint8_t token_len = (COAP_HEADER_TOKEN_LEN_MASK & message->data[0]) >>
-                        COAP_HEADER_TOKEN_LEN_POSITION;
+                      COAP_HEADER_TOKEN_LEN_POSITION;
   uint8_t *token = message->data + COAP_HEADER_LEN;
 
-  if (version == 1 && type == 1 && (code >> 5 == 0) && message->endpoint.flags & SECURED)
-  {
+  if (version == 1 && type == 1 && (code >> 5 == 0) &&
+      message->endpoint.flags & SECURED) {
     oc_replay_message_track(message, token_len, token);
   }
 

--- a/api/oc_buffer.c
+++ b/api/oc_buffer.c
@@ -180,7 +180,7 @@ oc_send_message(oc_message_t *message)
 
   if (version == 1 && type == 1 && (code >> 5 == 0))
   {
-    oc_replay_track_message(message, token_len, token);
+    oc_replay_message_track(message, token_len, token);
   }
 
   if (oc_process_post(&message_buffer_handler,

--- a/api/oc_buffer.c
+++ b/api/oc_buffer.c
@@ -83,7 +83,7 @@ allocate_message(struct oc_memb *pool)
     for (int i = 0; i < pool->num; ++i)
     {
       int offset = pool->size * i;
-      message = pool->mem + offset;
+      message = (oc_message_t*) pool->mem + offset;
 
       if (message->ref_count == 1 && message->soft_ref_cb != NULL)
       {

--- a/api/oc_buffer.c
+++ b/api/oc_buffer.c
@@ -89,7 +89,6 @@ allocate_message(struct oc_memb *pool)
       {
         // if found, call the callback, free the block and return it!
         message->soft_ref_cb(message);
-        oc_message_unref(message);
         // we know that was the last reference, so now we can allocate
         // a new message successfully
         return allocate_message(pool);

--- a/api/oc_buffer.c
+++ b/api/oc_buffer.c
@@ -90,6 +90,7 @@ allocate_message(struct oc_memb *pool)
       if (message->ref_count == 1 && message->soft_ref_cb != NULL)
       {
         // if found, call the callback, free the block and return it!
+        OC_WRN("Freeing echo retransmission candidate %p");
         message->soft_ref_cb(message);
         // we know that was the last reference, so now we can allocate
         // a new message successfully
@@ -178,7 +179,7 @@ oc_send_message(oc_message_t *message)
                         COAP_HEADER_TOKEN_LEN_POSITION;
   uint8_t *token = message->data + COAP_HEADER_LEN;
 
-  if (version == 1 && type == 1 && (code >> 5 == 0))
+  if (version == 1 && type == 1 && (code >> 5 == 0) && message->endpoint.flags & SECURED)
   {
     oc_replay_message_track(message, token_len, token);
   }

--- a/api/oc_knx_sec.h
+++ b/api/oc_knx_sec.h
@@ -16,39 +16,6 @@
 /**
   @brief knx application level security
   @file
-
-
-  ## Replay algorithm
-
-  The Replay window has 2 functions:
-
-  - avoid replay attacks on the server side.
-  - verify the oscore serial number if not yet known.
-
-  Description of the implemented replay window algorithm.
-
-  The KNX servers keep a list endpoints that they have received a
-  'synchronized' message from. Upon boot, this list endpoints is empty, so
-  servers will respond to requests from all new client endpoints with `4.01
-  UNAUTHORISED` message containing an Echo option. The echo option is
-  OSCORE-encrypted, and its actual value is the local time of the server. Upon
-  receiving such a response, the client retransmits the request and includes the
-  Echo value that the server sent. This verifies that:
-
-  a) the client is reachable at the source IP address, preventing attackers
-  from attempting to bypass the de-duplication code by changing the source IP
-  address of packets.
-
-  b) the request is fresh - the server drops request where the
-  time stamp contained in the Echo option is older than a given threshold,
-  configurable within engine.c.
-
-  The handling of the replay is transparent to the higher layers.
-  So the return code `4.01 UNAUTHORISED` does not
-  reach the client callback. The only observable side-effect is that the first
-  request sent to a 'new' server will have a slightly longer latency: twice the
-  round-trip time, as opposed to just once.
-
 */
 
 #ifndef OC_KNX_SEC_INTERNAL_H

--- a/api/oc_replay.c
+++ b/api/oc_replay.c
@@ -21,7 +21,6 @@
 #include "oc_knx_sec.h"
 #include "oc_config.h"
 #include "messaging/coap/constants.h"
-#include "oc_buffer.h"
 #include "oc_api.h"
 
 #ifndef OC_MAX_REPLAY_RECORDS
@@ -229,14 +228,6 @@ oc_replay_free_client(oc_string_t rx_kid)
   }
 }
 
-/*
- * Add functions fro:
- *  - track this message pls
- *  - free tracked message record (and stop callback)
- *  - free tracked message after timeout
- *  - free record because message was freed
- */
-
 struct oc_message_s * oc_replay_find_msg_by_token(uint16_t token_len, uint8_t *token)
 {
   for (int i = 0; i < OC_MAX_MESSAGE_RECORDS; ++i)
@@ -272,11 +263,13 @@ static struct oc_cached_message_record * find_empty_msg_record()
       return message_records + i;
   return NULL;
 }
-oc_event_callback_retval_t oc_replay_free_msg_handler(void *msg)
+
+static oc_event_callback_retval_t oc_replay_free_msg_handler(void *msg)
 {
   struct oc_cached_message_record *rec = find_record_by_msg(msg);
   rec->token_len = 0;
   rec->message = NULL;
+  oc_message_unref(msg);
   return OC_EVENT_DONE;
 }
 

--- a/api/oc_replay.c
+++ b/api/oc_replay.c
@@ -268,8 +268,8 @@ static oc_event_callback_retval_t oc_replay_free_msg_handler(void *msg)
   struct oc_cached_message_record *rec = find_record_by_msg(msg);
   if (msg)
   {
-    OC_DBG("Freeing tracked mesage %p with token:", msg);
-    OC_LOGbytes(rec->token, rec->token_len);
+    // OC_DBG("Freeing tracked message %p with token:", msg);
+    // OC_LOGbytes(rec->token, rec->token_len);
     rec->token_len = 0;
     rec->message = NULL;
     oc_message_unref(msg);
@@ -280,7 +280,7 @@ static oc_event_callback_retval_t oc_replay_free_msg_handler(void *msg)
 void oc_replay_message_unref(struct oc_message_s *msg)
 {
   oc_replay_free_msg_handler(msg);
-  OC_DBG("Removing callback...");
+  // OC_DBG("Removing callback...");
   oc_remove_delayed_callback(msg, oc_replay_free_msg_handler);
 }
 
@@ -289,8 +289,8 @@ void oc_replay_message_track(struct oc_message_s *msg, uint16_t token_len, uint8
   struct oc_cached_message_record *rec = find_empty_msg_record();
   if (rec == NULL)
     return;
-  OC_DBG("Tracking message %p with token:", msg);
-  OC_LOGbytes(token, token_len);
+  // OC_DBG("Tracking message %p with token:", msg);
+  // OC_LOGbytes(token, token_len);
   oc_message_add_ref(msg);
   msg->soft_ref_cb = oc_replay_message_unref;
 

--- a/api/oc_replay.c
+++ b/api/oc_replay.c
@@ -228,23 +228,23 @@ oc_replay_free_client(oc_string_t rx_kid)
   }
 }
 
-struct oc_message_s * oc_replay_find_msg_by_token(uint16_t token_len, uint8_t *token)
+struct oc_message_s *
+oc_replay_find_msg_by_token(uint16_t token_len, uint8_t *token)
 {
-  for (int i = 0; i < OC_MAX_MESSAGE_RECORDS; ++i)
-  {
+  for (int i = 0; i < OC_MAX_MESSAGE_RECORDS; ++i) {
     if (message_records[i].message == NULL)
       continue;
 
-      if(message_records[i].token_len == token_len)
-      {
-        if (memcmp(token, message_records[i].token, token_len) == 0)
-          return message_records[i].message;
-      }
+    if (message_records[i].token_len == token_len) {
+      if (memcmp(token, message_records[i].token, token_len) == 0)
+        return message_records[i].message;
+    }
   }
   return NULL;
 }
 
-static struct oc_cached_message_record * find_record_by_msg(struct oc_message_s *msg)
+static struct oc_cached_message_record *
+find_record_by_msg(struct oc_message_s *msg)
 {
   if (msg == NULL)
     return NULL;
@@ -255,7 +255,8 @@ static struct oc_cached_message_record * find_record_by_msg(struct oc_message_s 
   return NULL;
 }
 
-static struct oc_cached_message_record * find_empty_msg_record()
+static struct oc_cached_message_record *
+find_empty_msg_record()
 {
   for (int i = 0; i < OC_MAX_MESSAGE_RECORDS; ++i)
     if (message_records[i].message == NULL)
@@ -263,11 +264,11 @@ static struct oc_cached_message_record * find_empty_msg_record()
   return NULL;
 }
 
-static oc_event_callback_retval_t oc_replay_free_msg_handler(void *msg)
+static oc_event_callback_retval_t
+oc_replay_free_msg_handler(void *msg)
 {
   struct oc_cached_message_record *rec = find_record_by_msg(msg);
-  if (msg)
-  {
+  if (msg) {
     // OC_DBG("Freeing tracked message %p with token:", msg);
     // OC_LOGbytes(rec->token, rec->token_len);
     rec->token_len = 0;
@@ -277,14 +278,17 @@ static oc_event_callback_retval_t oc_replay_free_msg_handler(void *msg)
   return OC_EVENT_DONE;
 }
 
-void oc_replay_message_unref(struct oc_message_s *msg)
+void
+oc_replay_message_unref(struct oc_message_s *msg)
 {
   oc_replay_free_msg_handler(msg);
   // OC_DBG("Removing callback...");
   oc_remove_delayed_callback(msg, oc_replay_free_msg_handler);
 }
 
-void oc_replay_message_track(struct oc_message_s *msg, uint16_t token_len, uint8_t *token)
+void
+oc_replay_message_track(struct oc_message_s *msg, uint16_t token_len,
+                        uint8_t *token)
 {
   struct oc_cached_message_record *rec = find_empty_msg_record();
   if (rec == NULL)
@@ -298,5 +302,6 @@ void oc_replay_message_track(struct oc_message_s *msg, uint16_t token_len, uint8
   memcpy(rec->token, token, token_len);
   rec->message = msg;
 
-  oc_set_delayed_callback(msg, oc_replay_free_msg_handler, OC_REPLAY_RECORD_TIMEOUT);
+  oc_set_delayed_callback(msg, oc_replay_free_msg_handler,
+                          OC_REPLAY_RECORD_TIMEOUT);
 }

--- a/api/oc_replay.c
+++ b/api/oc_replay.c
@@ -273,19 +273,19 @@ static oc_event_callback_retval_t oc_replay_free_msg_handler(void *msg)
   return OC_EVENT_DONE;
 }
 
-void oc_replay_free_msg_cb(struct oc_message_s *msg)
+void oc_replay_message_unref(struct oc_message_s *msg)
 {
   oc_replay_free_msg_handler(msg);
   oc_remove_delayed_callback(msg, oc_replay_free_msg_handler);
 }
 
-void oc_replay_track_message(struct oc_message_s *msg, uint16_t token_len, uint8_t *token)
+void oc_replay_message_track(struct oc_message_s *msg, uint16_t token_len, uint8_t *token)
 {
   struct oc_cached_message_record *rec = find_empty_msg_record();
   if (rec == NULL)
     return;
   oc_message_add_ref(msg);
-  msg->soft_ref_cb = oc_replay_free_msg_cb;
+  msg->soft_ref_cb = oc_replay_message_unref;
 
   rec->token_len = token_len;
   memcpy(rec->token, token, token_len);

--- a/api/oc_replay.h
+++ b/api/oc_replay.h
@@ -82,7 +82,7 @@ void oc_replay_free_client(oc_string_t rx_kid);
 void oc_replay_message_track(struct oc_message_s *msg, uint16_t token_len, uint8_t *token);
 
 /**
- * @brief Free a message that was previously marked with oc_replay_track_message()
+ * @brief Free a message that was previously marked with oc_replay_message_track()
  *
  * @param msg pointer to the message buffer
  */

--- a/api/oc_replay.h
+++ b/api/oc_replay.h
@@ -79,14 +79,14 @@ void oc_replay_free_client(oc_string_t rx_kid);
  * @param token_len the length of the message's token
  * @param token the token, used for identifying the message
  */
-void oc_replay_track_message(struct oc_message_s *msg, uint16_t token_len, uint8_t *token);
+void oc_replay_message_track(struct oc_message_s *msg, uint16_t token_len, uint8_t *token);
 
 /**
  * @brief Free a message that was previously marked with oc_replay_track_message()
  *
  * @param msg pointer to the message buffer
  */
-void oc_replay_free_msg_cb(struct oc_message_s *msg);
+void oc_replay_message_unref(struct oc_message_s *msg);
 
 /**
  * @brief Find a previously tracked message and mark it as no longer tracked

--- a/api/oc_replay.h
+++ b/api/oc_replay.h
@@ -68,8 +68,9 @@ void oc_replay_free_client(oc_string_t rx_kid);
  * the stack runs out of buffers, or after a timeout.
  *
  * If static message buffers are used, this can lead to to a constrained client
- * having to drop messages that are otherwise preserved for echo retransmissions,
- * if many requests are being sent out in a short period of time.
+ * having to drop messages that are otherwise preserved for echo
+ * retransmissions, if many requests are being sent out in a short period of
+ * time.
  *
  * Messages that need to be retransmitted are identified by the token of 4.01
  * Unauthorised requests with an Echo option which must be included in the
@@ -79,10 +80,12 @@ void oc_replay_free_client(oc_string_t rx_kid);
  * @param token_len the length of the message's token
  * @param token the token, used for identifying the message
  */
-void oc_replay_message_track(struct oc_message_s *msg, uint16_t token_len, uint8_t *token);
+void oc_replay_message_track(struct oc_message_s *msg, uint16_t token_len,
+                             uint8_t *token);
 
 /**
- * @brief Free a message that was previously marked with oc_replay_message_track()
+ * @brief Free a message that was previously marked with
+ * oc_replay_message_track()
  *
  * @param msg pointer to the message buffer
  */
@@ -91,14 +94,15 @@ void oc_replay_message_unref(struct oc_message_s *msg);
 /**
  * @brief Find a previously tracked message and mark it as no longer tracked
  *
- * The soft reference will be removed. If this is the last remaining reference to the
- * message, the message will be freed.
+ * The soft reference will be removed. If this is the last remaining reference
+ * to the message, the message will be freed.
  *
  * @param token_len Length of the token
  * @param token Token used to identify the message
- * @return struct oc_message_s* 
+ * @return struct oc_message_s*
  */
-struct oc_message_s * oc_replay_find_msg_by_token(uint16_t token_len, uint8_t *token);
+struct oc_message_s *oc_replay_find_msg_by_token(uint16_t token_len,
+                                                 uint8_t *token);
 
 #ifdef __cplusplus
 }

--- a/api/oc_replay.h
+++ b/api/oc_replay.h
@@ -21,6 +21,7 @@ extern "C" {
 #endif
 
 #include "oc_helpers.h"
+#include "oc_buffer.h"
 
 /**
  * @brief Add a synchronised client
@@ -59,6 +60,45 @@ bool oc_replay_check_client(uint64_t rx_ssn, oc_string_t rx_kid,
  * @param rx_kid the KID
  */
 void oc_replay_free_client(oc_string_t rx_kid);
+
+/**
+ * @brief Mark a message to be retained for retransmission
+ *
+ * The message is retained using a soft reference - it will not be freed unless
+ * the stack runs out of buffers, or after a timeout.
+ *
+ * If static message buffers are used, this can lead to to a constrained client
+ * having to drop messages that are otherwise preserved for echo retransmissions,
+ * if many requests are being sent out in a short period of time.
+ *
+ * Messages that need to be retransmitted are identified by the token of 4.01
+ * Unauthorised requests with an Echo option which must be included in the
+ * retransmitted request.
+ *
+ * @param msg the message to be retained
+ * @param token_len the length of the message's token
+ * @param token the token, used for identifying the message
+ */
+void oc_replay_track_message(struct oc_message_s *msg, uint16_t token_len, uint8_t *token);
+
+/**
+ * @brief Free a message that was previously marked with oc_replay_track_message()
+ *
+ * @param msg pointer to the message buffer
+ */
+void oc_replay_free_msg_cb(struct oc_message_s *msg);
+
+/**
+ * @brief Find a previously tracked message and mark it as no longer tracked
+ *
+ * The soft reference will be removed. If this is the last remaining reference to the
+ * message, the message will be freed.
+ *
+ * @param token_len Length of the token
+ * @param token Token used to identify the message
+ * @return struct oc_message_s* 
+ */
+struct oc_message_s * oc_replay_find_msg_by_token(uint16_t token_len, uint8_t *token);
 
 #ifdef __cplusplus
 }

--- a/apps/simpleclient_spake_all.c
+++ b/apps/simpleclient_spake_all.c
@@ -223,7 +223,7 @@ discovery(const char *payload, int len, oc_endpoint_t *endpoint,
   oc_initiate_spake_parameter_request(endpoint, "00fa10010701", "LETTUCE",
                                       "rcpids", strlen("rcpids"));
 
-  oc_set_delayed_callback(&the_endpoint, do_pm, 10);
+  oc_set_delayed_callback(&the_endpoint, do_pm, 5);
 
   PRINT(" DISCOVERY- END\n");
   return OC_STOP_DISCOVERY;

--- a/apps/simpleclient_spake_all.c
+++ b/apps/simpleclient_spake_all.c
@@ -143,7 +143,7 @@ get_dev_pm(oc_client_response_t *data)
     PRINT("  get_dev_pm received : %d\n", rep->value.boolean);
   }
 
-  if (oc_init_put("/dev/pm", data->endpoint, NULL, &put_dev_pm, HIGH_QOS,
+  if (oc_init_put("/dev/pm", data->endpoint, NULL, &put_dev_pm, LOW_QOS,
                   NULL)) {
 
     cbor_encode_boolean(&g_encoder, true);
@@ -171,7 +171,7 @@ do_pm(void *ep)
   }
   oc_endpoint_t *endpoint = ep;
   endpoint->flags |= SECURED | OSCORE;
-  oc_do_get("/dev/pm", endpoint, NULL, callback, HIGH_QOS, NULL);
+  oc_do_get("/dev/pm", endpoint, NULL, callback, LOW_QOS, NULL);
   return OC_EVENT_CONTINUE;
 }
 
@@ -223,7 +223,7 @@ discovery(const char *payload, int len, oc_endpoint_t *endpoint,
   oc_initiate_spake_parameter_request(endpoint, "00fa10010701", "LETTUCE",
                                       "rcpids", strlen("rcpids"));
 
-  oc_set_delayed_callback(&the_endpoint, do_pm, 10);
+  oc_set_delayed_callback(&the_endpoint, do_pm, 2);
 
   PRINT(" DISCOVERY- END\n");
   return OC_STOP_DISCOVERY;

--- a/apps/simpleclient_spake_all.c
+++ b/apps/simpleclient_spake_all.c
@@ -223,7 +223,7 @@ discovery(const char *payload, int len, oc_endpoint_t *endpoint,
   oc_initiate_spake_parameter_request(endpoint, "00fa10010701", "LETTUCE",
                                       "rcpids", strlen("rcpids"));
 
-  oc_set_delayed_callback(&the_endpoint, do_pm, 2);
+  oc_set_delayed_callback(&the_endpoint, do_pm, 10);
 
   PRINT(" DISCOVERY- END\n");
   return OC_STOP_DISCOVERY;

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -342,14 +342,6 @@ coap_receive(oc_message_t *msg)
       }
       else
       {
-        // no transaction
-        // note that the coap pkt type uses a pointer for the payload!!
-        // so you will have to keep the original message around while
-        // sending the retransmission
-
-        // so, add a reference to old one, send new one, unref old one &
-        // soft-unref old one too!
-
         uint8_t echo_value[COAP_ECHO_LEN];
         size_t echo_len = coap_get_header_echo(message, echo_value);
         if (message->code == UNAUTHORIZED_4_01 && echo_len != 0) {
@@ -390,9 +382,8 @@ coap_receive(oc_message_t *msg)
             retransmitted_message->length = coap_oscore_serialize_message(
               retransmitted_pkt, retransmitted_message->data, true, true,
               true);
-            // send without transaction
-            coap_send_message(retransmitted_message);
 
+            coap_send_message(retransmitted_message);
             // unref original message
             oc_message_unref(original_message);
             oc_replay_message_unref(original_message);

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -287,10 +287,6 @@ coap_receive(oc_message_t *msg)
         // for which we have a transaction. This includes Echo retransmissions
         // for unicast acknowledged requests, but not NON requests, or
         // multicast S-Mode messages (which are always NON)
-
-        // We need a new mechanism for retransmission of NON requests, which
-        // is separate from transactions but works in a similar way, and does
-        // not take up more memory than necessary
         uint8_t echo_value[COAP_ECHO_LEN];
         size_t echo_len = coap_get_header_echo(message, echo_value);
         if (message->code == UNAUTHORIZED_4_01 && echo_len != 0) {
@@ -343,6 +339,71 @@ coap_receive(oc_message_t *msg)
 #endif
 
         coap_clear_transaction(transaction);
+      }
+      else
+      {
+        // no transaction
+        // note that the coap pkt type uses a pointer for the payload!!
+        // so you will have to keep the original message around while
+        // sending the retransmission
+
+        // so, add a reference to old one, send new one, unref old one &
+        // soft-unref old one too!
+
+        uint8_t echo_value[COAP_ECHO_LEN];
+        size_t echo_len = coap_get_header_echo(message, echo_value);
+        if (message->code == UNAUTHORIZED_4_01 && echo_len != 0) {
+          // find in oc_replay tracker and retransmit
+          oc_message_t *original_message = oc_replay_find_msg_by_token(message->token_len, message->token);
+          if(original_message)
+          {
+            // parse the original message, just like in the case where we have a transaction
+            coap_packet_t retransmitted_pkt[1];
+            coap_udp_parse_message(retransmitted_pkt, original_message->data,
+                                  (uint16_t)original_message->length);
+
+            client_cb = oc_ri_find_client_cb_by_mid(retransmitted_pkt->mid);
+            OC_DBG("Pointer to MID Client Callback: %p", client_cb);
+
+            // copy the echo from the unauthorised response into the new request
+            coap_set_header_echo(retransmitted_pkt, echo_value, echo_len);
+            int i = 0;
+            while (i < retransmitted_pkt->token_len) {
+              int r = oc_random_value();
+              memcpy(retransmitted_pkt->token + i, &r, sizeof(r));
+              i += sizeof(r);
+            }
+            retransmitted_pkt->mid = coap_get_mid();
+          
+            // a little bit naughty - modify the old client callback to refer to
+            // the new (retransmitted) packet
+            client_cb->mid = retransmitted_pkt->mid;
+            client_cb->token_len = retransmitted_pkt->token_len;
+            memcpy(client_cb->token, retransmitted_pkt->token,
+                  client_cb->token_len);
+
+            // add reference to original message so that it is not freed while we still need it
+            oc_message_add_ref(original_message);
+
+            oc_message_t *retransmitted_message = oc_internal_allocate_outgoing_message();
+            retransmitted_message->endpoint = original_message->endpoint;
+            retransmitted_message->length = coap_oscore_serialize_message(
+              retransmitted_pkt, retransmitted_message->data, true, true,
+              true);
+            // send without transaction
+            coap_send_message(retransmitted_message);
+
+            // unref original message
+            oc_message_unref(original_message);
+            oc_replay_message_unref(original_message);
+          }
+          else
+          {
+            // need to retransmit but no longer have original buffer. just drop it.
+            OC_ERR("=== Could not find original request for response with echo! Dropping! ===");
+            return 0;
+          }
+        }
       }
       transaction = NULL;
     }

--- a/port/linux/oc_config.h
+++ b/port/linux/oc_config.h
@@ -26,6 +26,10 @@
 extern "C" {
 #endif
 
+// FOR TESTING
+#define OC_INOUT_BUFFER_POOL 2
+#define OC_INOUT_BUFFER_SIZE (1232)
+
 typedef uint64_t oc_clock_time_t;
 #define OC_CLOCK_CONF_TICKS_PER_SECOND CLOCKS_PER_SEC
 

--- a/port/linux/oc_config.h
+++ b/port/linux/oc_config.h
@@ -26,10 +26,6 @@
 extern "C" {
 #endif
 
-// FOR TESTING
-#define OC_INOUT_BUFFER_POOL 2
-#define OC_INOUT_BUFFER_SIZE (1232)
-
 typedef uint64_t oc_clock_time_t;
 #define OC_CLOCK_CONF_TICKS_PER_SECOND CLOCKS_PER_SEC
 

--- a/port/oc_connectivity.h
+++ b/port/oc_connectivity.h
@@ -102,8 +102,6 @@ extern "C" {
 #define OC_MAX_APP_DATA_SIZE (oc_get_max_app_data_size())
 #endif /* OC_DYNAMIC_ALLOCATION */
 
-
-
 struct oc_message_s
 {
   struct oc_message_s *next;

--- a/port/oc_connectivity.h
+++ b/port/oc_connectivity.h
@@ -102,6 +102,8 @@ extern "C" {
 #define OC_MAX_APP_DATA_SIZE (oc_get_max_app_data_size())
 #endif /* OC_DYNAMIC_ALLOCATION */
 
+
+
 struct oc_message_s
 {
   struct oc_message_s *next;
@@ -123,6 +125,7 @@ struct oc_message_s
   size_t read_offset;
 #endif /* OC_TCP */
   uint8_t encrypted;
+  void (*soft_ref_cb)(struct oc_message_s *);
 };
 
 /**

--- a/port/oc_log.h
+++ b/port/oc_log.h
@@ -290,7 +290,7 @@ extern "C" {
 #ifndef OC_NO_LOG_BYTES
 #define OC_LOGbytes(bytes, length)                                             \
   do {                                                                         \
-    PRINT("D: %s <%s:%d>: ", __FILENAME__, __func__, __LINE__);            \
+    PRINT("D: %s <%s:%d>: ", __FILENAME__, __func__, __LINE__);                \
     uint16_t i;                                                                \
     for (i = 0; i < (length); i++)                                             \
       PRINT(" %02X", (bytes)[i]);                                              \

--- a/port/oc_log.h
+++ b/port/oc_log.h
@@ -290,7 +290,7 @@ extern "C" {
 #ifndef OC_NO_LOG_BYTES
 #define OC_LOGbytes(bytes, length)                                             \
   do {                                                                         \
-    PRINT("DEBUG: %s <%s:%d>: ", __FILENAME__, __func__, __LINE__);            \
+    PRINT("D: %s <%s:%d>: ", __FILENAME__, __func__, __LINE__);            \
     uint16_t i;                                                                \
     for (i = 0; i < (length); i++)                                             \
       PRINT(" %02X", (bytes)[i]);                                              \

--- a/port/windows/oc_config.h
+++ b/port/windows/oc_config.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 // FOR TESTING
-#define OC_INOUT_BUFFER_POOL 2 
+#define OC_INOUT_BUFFER_POOL 2
 #define OC_INOUT_BUFFER_SIZE (1232)
 
 typedef uint64_t oc_clock_time_t;

--- a/port/windows/oc_config.h
+++ b/port/windows/oc_config.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 // FOR TESTING
-#define OC_INOUT_BUFFER_POOL 5
+#define OC_INOUT_BUFFER_POOL 2 
 #define OC_INOUT_BUFFER_SIZE (1232)
 
 typedef uint64_t oc_clock_time_t;

--- a/port/windows/oc_config.h
+++ b/port/windows/oc_config.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 // FOR TESTING
-#define OC_INOUT_BUFFER_POOL 2
+#define OC_INOUT_BUFFER_POOL 5
 #define OC_INOUT_BUFFER_SIZE (1232)
 
 typedef uint64_t oc_clock_time_t;

--- a/port/windows/oc_config.h
+++ b/port/windows/oc_config.h
@@ -8,6 +8,10 @@
 extern "C" {
 #endif
 
+// FOR TESTING
+#define OC_INOUT_BUFFER_POOL 2
+#define OC_INOUT_BUFFER_SIZE (1232)
+
 typedef uint64_t oc_clock_time_t;
 #define strncasecmp _strnicmp
 /* Sets one clock tick to 1 ms */

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -640,8 +640,7 @@ oc_oscore_send_message(oc_message_t *msg)
 
   /* Clone incoming oc_message_t (*msg) from CoAP layer */
   message = oc_internal_allocate_outgoing_message();
-  if (message == NULL)
-  {
+  if (message == NULL) {
     OC_ERR("***No memory to allocate outgoing message!***");
     goto oscore_send_error;
   }

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -640,6 +640,11 @@ oc_oscore_send_message(oc_message_t *msg)
 
   /* Clone incoming oc_message_t (*msg) from CoAP layer */
   message = oc_internal_allocate_outgoing_message();
+  if (message == NULL)
+  {
+    OC_ERR("***No memory to allocate outgoing message!***");
+    goto oscore_send_error;
+  }
   message->length = msg->length;
   memcpy(message->data, msg->data, msg->length);
   memcpy(&message->endpoint, &msg->endpoint, sizeof(oc_endpoint_t));


### PR DESCRIPTION
We couldn't do replay protection for NON requests before because the retransmission code for CON frames was piggybacking off of the pre-existing transactions, which already cached requests in case they were not acknowledged. NON frames used to be freed right after sending.

This pull request adds APIs for 'soft references' to `oc_message_t` - messages that only have a soft ref in their reference count are freed if & only if no other buffers are available. This API is used to hang onto NON frames in case a Echo challenge comes through which requires retransmitting the request.

I think it should be possible to use the new mechanism for CON frames as well without any real tradeoffs - this would get rid of the duplicated code in `oc_engine.c`