### PR TITLE
Generate recipient contexts dynamically using context ID of requests

### DIFF
--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1006,7 +1006,9 @@ oc_core_auth_at_x_delete_handler(oc_request_t *request,
   // do the persistent storage
   oc_at_dump_entry(device_index, index);
   // delete the related oscore contexts
+#ifdef OC_OSCORE
   oc_oscore_free_contexts_at_id(index);
+#endif
 
   PRINT("oc_core_auth_at_x_delete_handler - done\n");
   oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -526,6 +526,7 @@ oc_core_auth_at_get_handler(oc_request_t *request,
 static oc_event_callback_retval_t init_contexts_no_storage(void* device_p)
 {
   int device_index = (int) device_p;
+  OC_DBG("Delayed Init Contexts Callback firing...")
   oc_init_oscore_from_storage(device_index, false);
   return OC_EVENT_DONE;
 }
@@ -533,6 +534,7 @@ static oc_event_callback_retval_t init_contexts_no_storage(void* device_p)
 static oc_event_callback_retval_t delete_at_table(void* device_p)
 {
   int device_index = (int) device_p;
+  OC_DBG("Delayed Delete Contexts Callback firing...")
   oc_delete_at_table(device_index);
   return OC_EVENT_DONE;
 }
@@ -761,7 +763,7 @@ oc_core_auth_at_post_handler(oc_request_t *request,
     OC_WRN("update scope only");
   } else {
     // update the oscore context
-    oc_set_delayed_callback_ms((void*)device_index, init_contexts_no_storage, 0);
+    oc_set_delayed_callback_ms((void*)device_index, init_contexts_no_storage, 10);
   }
   PRINT("oc_core_auth_at_post_handler - end\n");
   oc_send_cbor_response_no_payload_size(request, return_status);
@@ -783,7 +785,7 @@ oc_core_auth_at_delete_handler(oc_request_t *request,
 
   size_t device_index = request->resource->device;
 
-  oc_set_delayed_callback_ms((void*)device_index, delete_at_table, 0);
+  oc_set_delayed_callback_ms((void*)device_index, delete_at_table, 10);
 
   PRINT("oc_core_auth_at_delete_handler - end\n");
   oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -763,7 +763,7 @@ oc_core_auth_at_post_handler(oc_request_t *request,
     OC_WRN("update scope only");
   } else {
     // update the oscore context
-    oc_set_delayed_callback_ms((void*)device_index, init_contexts_no_storage, 1000);
+    oc_set_delayed_callback_ms((void*)device_index, init_contexts_no_storage, 10);
   }
   PRINT("oc_core_auth_at_post_handler - end\n");
   oc_send_cbor_response_no_payload_size(request, return_status);
@@ -785,7 +785,7 @@ oc_core_auth_at_delete_handler(oc_request_t *request,
 
   size_t device_index = request->resource->device;
 
-  oc_set_delayed_callback_ms((void*)device_index, delete_at_table, 1000);
+  oc_set_delayed_callback_ms((void*)device_index, delete_at_table, 10);
 
   PRINT("oc_core_auth_at_delete_handler - end\n");
   oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);
@@ -1683,10 +1683,8 @@ oc_init_oscore_from_storage(size_t device_index, bool from_storage)
   (void)device_index;
 #else /* OC_OSCORE */
   int i;
-  OC_DBG_OSCORE("oc_init_oscore deleting old contexts!!");
-
-  // deleting all contexts!!
-  oc_oscore_free_all_contexts();
+  OC_DBG_OSCORE("oc_init_oscore deleting old sender contexts!!");
+  oc_oscore_free_sender_contexts();
 
   OC_DBG_OSCORE("oc_init_oscore adding OSCORE context...");
   for (i = 0; i < G_AT_MAX_ENTRIES; i++) {

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -523,6 +523,20 @@ oc_core_auth_at_get_handler(oc_request_t *request,
   PRINT("oc_core_auth_at_get_handler - end\n");
 }
 
+static oc_event_callback_retval_t init_contexts_no_storage(void* device_p)
+{
+  int device_index = (int) device_p;
+  oc_init_oscore_from_storage(device_index, false);
+  return OC_EVENT_DONE;
+}
+
+static oc_event_callback_retval_t delete_at_table(void* device_p)
+{
+  int device_index = (int) device_p;
+  oc_delete_at_table(device_index);
+  return OC_EVENT_DONE;
+}
+
 static void
 oc_core_auth_at_post_handler(oc_request_t *request,
                              oc_interface_mask_t iface_mask, void *data)
@@ -747,7 +761,7 @@ oc_core_auth_at_post_handler(oc_request_t *request,
     OC_WRN("update scope only");
   } else {
     // update the oscore context
-    oc_init_oscore_from_storage(device_index, false);
+    oc_set_delayed_callback_ms((void*)device_index, init_contexts_no_storage, 0);
   }
   PRINT("oc_core_auth_at_post_handler - end\n");
   oc_send_cbor_response_no_payload_size(request, return_status);
@@ -769,7 +783,7 @@ oc_core_auth_at_delete_handler(oc_request_t *request,
 
   size_t device_index = request->resource->device;
 
-  oc_delete_at_table(device_index);
+  oc_set_delayed_callback_ms((void*)device_index, delete_at_table, 0);
 
   PRINT("oc_core_auth_at_delete_handler - end\n");
   oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1000,7 +1000,7 @@ oc_core_auth_at_x_delete_handler(oc_request_t *request,
     PRINT("oc_core_auth_at_x_delete_handler: index in structure not found\n");
     return;
   }
-  
+
   // actual delete of the context id so that this entry is seen as empty
   oc_at_delete_entry(device_index, index);
   // do the persistent storage

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1451,6 +1451,19 @@ oc_core_find_at_entry_with_id(size_t device_index, char *id)
 }
 
 int
+oc_core_find_at_entry_with_osc_id(size_t device_index, uint8_t *osc_id, size_t osc_id_len)
+{
+  for (int i = 0; i < G_AT_MAX_ENTRIES; i++) {
+    if (oc_byte_string_len(g_at_entries[i].osc_id) == osc_id_len
+        && memcmp(oc_string(g_at_entries[i].osc_id), osc_id, osc_id_len) == 0)
+    {
+      return i;
+    }
+  }
+  return -1;
+}
+
+int
 oc_core_find_at_entry_empty_slot(size_t device_index)
 {
   for (int i = 0; i < G_AT_MAX_ENTRIES; i++) {
@@ -1570,10 +1583,6 @@ oc_oscore_set_auth_mac(char *client_senderid, int client_senderid_size,
                             shared_key, shared_key_size);
 }
 
-// This looks very similar to oc_oscore_set_auth_mac, but has some very
-// particular differences. The key identifier is the same as before (serial
-// number), but the sender & receiver IDs are swapped. Here, the sender ID is
-// client_recipientid, referring to the MAC. And the receiver ID is emtpy string
 void
 oc_oscore_set_auth_device(char *client_senderid, int client_senderid_size,
                           char *client_recipientid, int client_recipientid_size,
@@ -1688,22 +1697,10 @@ oc_init_oscore_from_storage(size_t device_index, bool from_storage)
         // the spake key, however, is for receiving only, and the osc_id is
         // already inside receiver_id.
 
-        // by default, posts to auth/at set id into the sender id, so the
-        // created contexts are only usable for sending. so we must create
-        // contexts for receiving with ids swapped
-
-        ctx = oc_oscore_add_context(
-          device_index, oc_string(g_at_entries[i].osc_rid),
-          oc_byte_string_len(g_at_entries[i].osc_rid),
-          oc_string(g_at_entries[i].osc_id),
-          oc_byte_string_len(g_at_entries[i].osc_id), ssn, "desc",
-          oc_string(g_at_entries[i].osc_ms),
-          oc_byte_string_len(g_at_entries[i].osc_ms),
-          oc_string(g_at_entries[i].osc_contextid),
-          oc_byte_string_len(g_at_entries[i].osc_contextid), i, from_storage);
-        if (ctx == NULL) {
-          OC_ERR("  failed to load index= %d", i);
-        }
+        // posts to auth/at set id into the sender id, so the created contexts 
+        // are only usable for sending. recipient contexts are created dynamically 
+        // with the key from the access token matching the key ID, and with the
+        // context id within the received request
       } else {
         OC_DBG_OSCORE("oc_init_oscore: no oscore context");
       }

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1451,12 +1451,12 @@ oc_core_find_at_entry_with_id(size_t device_index, char *id)
 }
 
 int
-oc_core_find_at_entry_with_osc_id(size_t device_index, uint8_t *osc_id, size_t osc_id_len)
+oc_core_find_at_entry_with_osc_id(size_t device_index, uint8_t *osc_id,
+                                  size_t osc_id_len)
 {
   for (int i = 0; i < G_AT_MAX_ENTRIES; i++) {
-    if (oc_byte_string_len(g_at_entries[i].osc_id) == osc_id_len
-        && memcmp(oc_string(g_at_entries[i].osc_id), osc_id, osc_id_len) == 0)
-    {
+    if (oc_byte_string_len(g_at_entries[i].osc_id) == osc_id_len &&
+        memcmp(oc_string(g_at_entries[i].osc_id), osc_id, osc_id_len) == 0) {
       return i;
     }
   }
@@ -1697,10 +1697,10 @@ oc_init_oscore_from_storage(size_t device_index, bool from_storage)
         // the spake key, however, is for receiving only, and the osc_id is
         // already inside receiver_id.
 
-        // posts to auth/at set id into the sender id, so the created contexts 
-        // are only usable for sending. recipient contexts are created dynamically 
-        // with the key from the access token matching the key ID, and with the
-        // context id within the received request
+        // posts to auth/at set id into the sender id, so the created contexts
+        // are only usable for sending. recipient contexts are created
+        // dynamically with the key from the access token matching the key ID,
+        // and with the context id within the received request
       } else {
         OC_DBG_OSCORE("oc_init_oscore: no oscore context");
       }

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -526,7 +526,7 @@ oc_core_auth_at_get_handler(oc_request_t *request,
 static oc_event_callback_retval_t init_contexts_no_storage(void* device_p)
 {
   int device_index = (int) device_p;
-  OC_DBG("Delayed Init Contexts Callback firing...")
+  OC_DBG("Delayed Init Contexts Callback firing...");
   oc_init_oscore_from_storage(device_index, false);
   return OC_EVENT_DONE;
 }
@@ -534,7 +534,7 @@ static oc_event_callback_retval_t init_contexts_no_storage(void* device_p)
 static oc_event_callback_retval_t delete_at_table(void* device_p)
 {
   int device_index = (int) device_p;
-  OC_DBG("Delayed Delete Contexts Callback firing...")
+  OC_DBG("Delayed Delete Contexts Callback firing...");
   oc_delete_at_table(device_index);
   return OC_EVENT_DONE;
 }

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -523,22 +523,6 @@ oc_core_auth_at_get_handler(oc_request_t *request,
   PRINT("oc_core_auth_at_get_handler - end\n");
 }
 
-static oc_event_callback_retval_t init_contexts_no_storage(void* device_p)
-{
-  int device_index = (int) device_p;
-  OC_DBG("Delayed Init Contexts Callback firing...");
-  oc_init_oscore_from_storage(device_index, false);
-  return OC_EVENT_DONE;
-}
-
-static oc_event_callback_retval_t delete_at_table(void* device_p)
-{
-  int device_index = (int) device_p;
-  OC_DBG("Delayed Delete Contexts Callback firing...");
-  oc_delete_at_table(device_index);
-  return OC_EVENT_DONE;
-}
-
 static void
 oc_core_auth_at_post_handler(oc_request_t *request,
                              oc_interface_mask_t iface_mask, void *data)
@@ -763,7 +747,7 @@ oc_core_auth_at_post_handler(oc_request_t *request,
     OC_WRN("update scope only");
   } else {
     // update the oscore context
-    oc_set_delayed_callback_ms((void*)device_index, init_contexts_no_storage, 10);
+    oc_init_oscore_from_storage(device_index, false);
   }
   PRINT("oc_core_auth_at_post_handler - end\n");
   oc_send_cbor_response_no_payload_size(request, return_status);
@@ -784,8 +768,7 @@ oc_core_auth_at_delete_handler(oc_request_t *request,
   }
 
   size_t device_index = request->resource->device;
-
-  oc_set_delayed_callback_ms((void*)device_index, delete_at_table, 10);
+  oc_delete_at_table(device_index);
 
   PRINT("oc_core_auth_at_delete_handler - end\n");
   oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1000,12 +1000,14 @@ oc_core_auth_at_x_delete_handler(oc_request_t *request,
     PRINT("oc_core_auth_at_x_delete_handler: index in structure not found\n");
     return;
   }
+  
   // actual delete of the context id so that this entry is seen as empty
   oc_at_delete_entry(device_index, index);
   // do the persistent storage
   oc_at_dump_entry(device_index, index);
-  // remove the key by reinitializing all used oscore keys.
-  oc_init_oscore_from_storage(device_index, false);
+  // delete the related oscore contexts
+  oc_oscore_free_contexts_at_id(index);
+
   PRINT("oc_core_auth_at_x_delete_handler - done\n");
   oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);
 }

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -763,7 +763,7 @@ oc_core_auth_at_post_handler(oc_request_t *request,
     OC_WRN("update scope only");
   } else {
     // update the oscore context
-    oc_set_delayed_callback_ms((void*)device_index, init_contexts_no_storage, 10);
+    oc_set_delayed_callback_ms((void*)device_index, init_contexts_no_storage, 1000);
   }
   PRINT("oc_core_auth_at_post_handler - end\n");
   oc_send_cbor_response_no_payload_size(request, return_status);
@@ -785,7 +785,7 @@ oc_core_auth_at_delete_handler(oc_request_t *request,
 
   size_t device_index = request->resource->device;
 
-  oc_set_delayed_callback_ms((void*)device_index, delete_at_table, 10);
+  oc_set_delayed_callback_ms((void*)device_index, delete_at_table, 1000);
 
   PRINT("oc_core_auth_at_delete_handler - end\n");
   oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);

--- a/api/oc_knx_sec.h
+++ b/api/oc_knx_sec.h
@@ -184,10 +184,22 @@ int oc_core_set_at_table(size_t device_index, int index, oc_auth_at_t entry,
  * @param device_index The device index
  * @param context_id the context id to search for
  * @return int -1 : no entry with that name
- * @return int >=0 : entry found
+ * @return int >=0 : index of found entry
  */
 int oc_core_find_at_entry_with_context_id(size_t device_index,
                                           char *context_id);
+
+/**
+ * @brief Find an entry with a given OSCORE ID
+ * 
+ * @param device_index The device index
+ * @param osc_id the oscore ID to search for
+ * @param osc_id_len length of the context
+ * @return int -1 : no entry with that oscore id
+ * @return int >= index of found entry
+ */
+int
+oc_core_find_at_entry_with_osc_id(size_t device_index, uint8_t *osc_id, size_t osc_id_len);
 
 /**
  * @brief find empty slot

--- a/api/oc_knx_sec.h
+++ b/api/oc_knx_sec.h
@@ -191,15 +191,15 @@ int oc_core_find_at_entry_with_context_id(size_t device_index,
 
 /**
  * @brief Find an entry with a given OSCORE ID
- * 
+ *
  * @param device_index The device index
  * @param osc_id the oscore ID to search for
  * @param osc_id_len length of the context
  * @return int -1 : no entry with that oscore id
  * @return int >= index of found entry
  */
-int
-oc_core_find_at_entry_with_osc_id(size_t device_index, uint8_t *osc_id, size_t osc_id_len);
+int oc_core_find_at_entry_with_osc_id(size_t device_index, uint8_t *osc_id,
+                                      size_t osc_id_len);
 
 /**
  * @brief find empty slot

--- a/port/windows/oc_config.h
+++ b/port/windows/oc_config.h
@@ -8,10 +8,6 @@
 extern "C" {
 #endif
 
-// FOR TESTING
-#define OC_INOUT_BUFFER_POOL 2
-#define OC_INOUT_BUFFER_SIZE (1232)
-
 typedef uint64_t oc_clock_time_t;
 #define strncasecmp _strnicmp
 /* Sets one clock tick to 1 ms */

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -366,7 +366,8 @@ oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
   oc_char_println_hex(senderid, senderid_size);
   PRINT("  rid size  : %d ", recipientid_size);
   oc_char_println_hex(recipientid, recipientid_size);
-  PRINT("  ctx size  : %d\n", osc_ctx_size);
+  PRINT("  ctx size  : %d", osc_ctx_size);
+  oc_char_println_hex(osc_ctx, osc_ctx_size);
   PRINT("  ms size   : %d ", mastersecret_size);
   oc_char_println_hex(mastersecret, mastersecret_size);
 

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -306,7 +306,8 @@ oc_oscore_free_all_contexts()
   oc_list_init(contexts);
 }
 
-void oc_oscore_free_sender_contexts()
+void
+oc_oscore_free_sender_contexts()
 {
   oc_oscore_context_t *ctx = (oc_oscore_context_t *)oc_list_head(contexts);
   while (ctx != NULL) {
@@ -317,7 +318,8 @@ void oc_oscore_free_sender_contexts()
   }
 }
 
-void oc_oscore_free_contexts_at_id(int auth_at_index)
+void
+oc_oscore_free_contexts_at_id(int auth_at_index)
 {
   oc_oscore_context_t *ctx = (oc_oscore_context_t *)oc_list_head(contexts);
   while (ctx != NULL) {

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -317,6 +317,17 @@ void oc_oscore_free_sender_contexts()
   }
 }
 
+void oc_oscore_free_contexts_at_id(int auth_at_index)
+{
+  oc_oscore_context_t *ctx = (oc_oscore_context_t *)oc_list_head(contexts);
+  while (ctx != NULL) {
+    oc_oscore_context_t *next = ctx->next;
+    if (ctx->auth_at_index == auth_at_index)
+      oc_oscore_free_context(ctx);
+    ctx = next;
+  }
+}
+
 void
 oc_oscore_free_context(oc_oscore_context_t *ctx)
 {

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -306,6 +306,17 @@ oc_oscore_free_all_contexts()
   oc_list_init(contexts);
 }
 
+void oc_oscore_free_sender_contexts()
+{
+  oc_oscore_context_t *ctx = (oc_oscore_context_t *)oc_list_head(contexts);
+  while (ctx != NULL) {
+    oc_oscore_context_t *next = ctx->next;
+    if (ctx->recvid_len == 0)
+      oc_oscore_free_context(ctx);
+    ctx = next;
+  }
+}
+
 void
 oc_oscore_free_context(oc_oscore_context_t *ctx)
 {

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -32,13 +32,13 @@
 OC_LIST(contexts);
 OC_MEMB(ctx_s, oc_oscore_context_t, 20);
 
-void oc_oscore_free_lru_recipient_context(void)
+void
+oc_oscore_free_lru_recipient_context(void)
 {
   oc_oscore_context_t *ctx, *lru_ctx;
   ctx = lru_ctx = oc_list_head(contexts);
 
-  while(ctx != NULL)
-  {
+  while (ctx != NULL) {
     if (ctx->sendid_len == 0 && ctx->last_used < lru_ctx->last_used)
       lru_ctx = ctx;
 
@@ -79,8 +79,10 @@ oc_oscore_find_context_by_kid(oc_oscore_context_t *ctx, size_t device_index,
 }
 
 oc_oscore_context_t *
-oc_oscore_find_context_by_kid_idctx(oc_oscore_context_t *ctx, size_t device_index,
-                              uint8_t *kid, uint8_t kid_len, uint8_t *kid_ctx, uint8_t kid_ctx_len)
+oc_oscore_find_context_by_kid_idctx(oc_oscore_context_t *ctx,
+                                    size_t device_index, uint8_t *kid,
+                                    uint8_t kid_len, uint8_t *kid_ctx,
+                                    uint8_t kid_ctx_len)
 {
   if (!ctx) {
     ctx = (oc_oscore_context_t *)oc_list_head(contexts);
@@ -97,9 +99,9 @@ oc_oscore_find_context_by_kid_idctx(oc_oscore_context_t *ctx, size_t device_inde
     PRINT("  ---> recvid:");
     oc_char_println_hex((char *)(ctx->recvid), ctx->recvid_len);
 
-    if (kid_len == ctx->recvid_len && memcmp(kid, ctx->recvid, kid_len) == 0
-      && kid_ctx_len == ctx->idctx_len && memcmp(kid_ctx, ctx->idctx, kid_ctx_len) == 0
-    ) {
+    if (kid_len == ctx->recvid_len && memcmp(kid, ctx->recvid, kid_len) == 0 &&
+        kid_ctx_len == ctx->idctx_len &&
+        memcmp(kid_ctx, ctx->idctx, kid_ctx_len) == 0) {
       PRINT("oc_oscore_find_context_by_kid_idctx FOUND  auth/at index: %d\n",
             ctx->auth_at_index);
       ctx->last_used = oc_clock_time();

--- a/security/oc_oscore_context.h
+++ b/security/oc_oscore_context.h
@@ -122,6 +122,12 @@ void oc_oscore_free_context(oc_oscore_context_t *ctx);
 void oc_oscore_free_all_contexts();
 
 /**
+ * @brief free all OSCORE sender contexts
+ *
+ */
+void oc_oscore_free_sender_contexts();
+
+/**
  * @brief creates an OSCORE context (e.g. the internal structure for
  encoding/decoding)
  *

--- a/security/oc_oscore_context.h
+++ b/security/oc_oscore_context.h
@@ -20,6 +20,7 @@
 
 #include "messaging/coap/oscore_constants.h"
 #include "oc_helpers.h"
+#include "oc_clock.h"
 #include "oc_uuid.h"
 #include <inttypes.h>
 #include <stdbool.h>
@@ -81,8 +82,8 @@ typedef struct oc_oscore_context_t
   uint8_t recvkey[OSCORE_KEY_LEN]; /**< derived recipient key */
   /* Common IV */
   uint8_t commoniv[OSCORE_COMMON_IV_LEN];
-  /* Replay Window */
-  // TODO make the replay window configurable from CMake
+  /* Time of last use, for runtime caching of recipient contexts */
+  oc_clock_time_t last_used;
 } oc_oscore_context_t;
 
 /**
@@ -152,6 +153,15 @@ oc_oscore_context_t *oc_oscore_add_context(
   const char *mastersecret, int mastersecret_size, const char *token_id,
   int token_id_size, int auth_at_index, bool from_storage);
 
+/**
+ * @brief Free the least recently used recipient context
+ * 
+ * The use times are updated when the contexts are created or found using the
+ * find_context_by_* functions
+ * 
+ */
+void oc_oscore_free_lru_recipient_context(void);
+
 oc_oscore_context_t *oc_oscore_find_context_by_serial_number(
   size_t device, char *serial_number);
 
@@ -161,6 +171,9 @@ oc_oscore_context_t *oc_oscore_find_context_by_group_address(
 oc_oscore_context_t *oc_oscore_find_context_by_kid(oc_oscore_context_t *ctx,
                                                    size_t device, uint8_t *kid,
                                                    uint8_t kid_len);
+
+oc_oscore_context_t * oc_oscore_find_context_by_kid_idctx(oc_oscore_context_t *ctx, size_t device_index,
+                              uint8_t *kid, uint8_t kid_len, uint8_t *kid_ctx, uint8_t kid_ctx_len);
 
 oc_oscore_context_t *oc_oscore_find_context_by_token_mid(
   size_t device, uint8_t *token, uint8_t token_len, uint16_t mid,

--- a/security/oc_oscore_context.h
+++ b/security/oc_oscore_context.h
@@ -128,6 +128,13 @@ void oc_oscore_free_all_contexts();
 void oc_oscore_free_sender_contexts();
 
 /**
+ * @brief Free contexts with a given auth_at index
+ * 
+ * @param auth_at_index the index
+ */
+void oc_oscore_free_contexts_at_id(int auth_at_index);
+
+/**
  * @brief creates an OSCORE context (e.g. the internal structure for
  encoding/decoding)
  *

--- a/security/oc_oscore_context.h
+++ b/security/oc_oscore_context.h
@@ -155,10 +155,10 @@ oc_oscore_context_t *oc_oscore_add_context(
 
 /**
  * @brief Free the least recently used recipient context
- * 
+ *
  * The use times are updated when the contexts are created or found using the
  * find_context_by_* functions
- * 
+ *
  */
 void oc_oscore_free_lru_recipient_context(void);
 
@@ -172,8 +172,9 @@ oc_oscore_context_t *oc_oscore_find_context_by_kid(oc_oscore_context_t *ctx,
                                                    size_t device, uint8_t *kid,
                                                    uint8_t kid_len);
 
-oc_oscore_context_t * oc_oscore_find_context_by_kid_idctx(oc_oscore_context_t *ctx, size_t device_index,
-                              uint8_t *kid, uint8_t kid_len, uint8_t *kid_ctx, uint8_t kid_ctx_len);
+oc_oscore_context_t *oc_oscore_find_context_by_kid_idctx(
+  oc_oscore_context_t *ctx, size_t device_index, uint8_t *kid, uint8_t kid_len,
+  uint8_t *kid_ctx, uint8_t kid_ctx_len);
 
 oc_oscore_context_t *oc_oscore_find_context_by_token_mid(
   size_t device, uint8_t *token, uint8_t token_len, uint16_t mid,

--- a/security/oc_oscore_context.h
+++ b/security/oc_oscore_context.h
@@ -129,7 +129,7 @@ void oc_oscore_free_sender_contexts();
 
 /**
  * @brief Free contexts with a given auth_at index
- * 
+ *
  * @param auth_at_index the index
  */
 void oc_oscore_free_contexts_at_id(int auth_at_index);

--- a/security/oc_oscore_context.h
+++ b/security/oc_oscore_context.h
@@ -20,7 +20,7 @@
 
 #include "messaging/coap/oscore_constants.h"
 #include "oc_helpers.h"
-#include "oc_clock.h"
+#include "port/oc_clock.h"
 #include "oc_uuid.h"
 #include <inttypes.h>
 #include <stdbool.h>

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -198,6 +198,7 @@ oc_oscore_recv_message(oc_message_t *message)
 
         // if context is null, free one & try adding again
         if (!oscore_ctx) {
+          oc_oscore_free_lru_recipient_context();
           oscore_ctx = oc_oscore_add_context(
             0, oc_string(at_entry->osc_rid), /* sender id (empty string) */
             oc_byte_string_len(

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -167,56 +167,51 @@ oc_oscore_recv_message(oc_message_t *message)
       OC_DBG_OSCORE("--- got kid from incoming message");
       OC_LOGbytes(oscore_pkt->kid, oscore_pkt->kid_len);
       OC_DBG_OSCORE("### searching for OSCORE context by kid ###");
-      oscore_ctx =
-        oc_oscore_find_context_by_kid_idctx(oscore_ctx, message->endpoint.device,
-                                      oscore_pkt->kid, oscore_pkt->kid_len, oscore_pkt->kid_ctx, oscore_pkt->kid_ctx_len);
-      
-      if (!oscore_ctx)
-      {
+      oscore_ctx = oc_oscore_find_context_by_kid_idctx(
+        oscore_ctx, message->endpoint.device, oscore_pkt->kid,
+        oscore_pkt->kid_len, oscore_pkt->kid_ctx, oscore_pkt->kid_ctx_len);
+
+      if (!oscore_ctx) {
         // we do not have a cached context, so we have to make one
 
         // find auth/at entry with corresponding kid
-        int idx = oc_core_find_at_entry_with_osc_id(0, oscore_pkt->kid, oscore_pkt->kid_len);
-        if (idx == -1)
-        {
-          OC_ERR(
-            "***Could not find Access Token matching KID, returning UNAUTHORIZED***");
+        int idx = oc_core_find_at_entry_with_osc_id(0, oscore_pkt->kid,
+                                                    oscore_pkt->kid_len);
+        if (idx == -1) {
+          OC_ERR("***Could not find Access Token matching KID, returning "
+                 "UNAUTHORIZED***");
           oscore_send_error(oscore_pkt, UNAUTHORIZED_4_01, &message->endpoint);
           goto oscore_recv_error;
         }
         oc_auth_at_t *at_entry = oc_get_auth_at_entry(0, idx);
 
         // create oscore recipient context from that entry
-        oscore_ctx = oc_oscore_add_context(0,
-          oc_string(at_entry->osc_rid), /* sender id (empty string) */
-          oc_byte_string_len(at_entry->osc_rid), /* sender id len (ought to be 0)*/
+        oscore_ctx = oc_oscore_add_context(
+          0, oc_string(at_entry->osc_rid), /* sender id (empty string) */
+          oc_byte_string_len(
+            at_entry->osc_rid),        /* sender id len (ought to be 0)*/
           oc_string(at_entry->osc_id), /* recipient id */
           oc_byte_string_len(at_entry->osc_id), /* recipient id len */
-          0, "desc",
-          oc_string(at_entry->osc_ms),
-          oc_byte_string_len(at_entry->osc_ms),
-          oscore_pkt->kid_ctx,
+          0, "desc", oc_string(at_entry->osc_ms),
+          oc_byte_string_len(at_entry->osc_ms), oscore_pkt->kid_ctx,
           oscore_pkt->kid_ctx_len, idx, false);
 
         // if context is null, free one & try adding again
-        if (!oscore_ctx)
-        {
-          oscore_ctx = oc_oscore_add_context(0,
-            oc_string(at_entry->osc_rid), /* sender id (empty string) */
-            oc_byte_string_len(at_entry->osc_rid), /* sender id len (ought to be 0)*/
+        if (!oscore_ctx) {
+          oscore_ctx = oc_oscore_add_context(
+            0, oc_string(at_entry->osc_rid), /* sender id (empty string) */
+            oc_byte_string_len(
+              at_entry->osc_rid),        /* sender id len (ought to be 0)*/
             oc_string(at_entry->osc_id), /* recipient id */
             oc_byte_string_len(at_entry->osc_id), /* recipient id len */
-            0, "desc",
-            oc_string(at_entry->osc_ms),
-            oc_byte_string_len(at_entry->osc_ms),
-            oscore_pkt->kid_ctx,
+            0, "desc", oc_string(at_entry->osc_ms),
+            oc_byte_string_len(at_entry->osc_ms), oscore_pkt->kid_ctx,
             oscore_pkt->kid_ctx_len, idx, false);
-          if (!oscore_ctx)
-          {
+          if (!oscore_ctx) {
             OC_ERR("***Could not create oscore recipient context!***");
-            oscore_send_error(oscore_pkt, UNAUTHORIZED_4_01, &message->endpoint);
+            oscore_send_error(oscore_pkt, UNAUTHORIZED_4_01,
+                              &message->endpoint);
             goto oscore_recv_error;
-
           }
         }
       }
@@ -749,9 +744,10 @@ oc_oscore_send_message(oc_message_t *msg)
     /* Use sender key for encryption */
     uint8_t *key = oscore_ctx->sendkey;
 
-    uint8_t piv[OSCORE_PIV_LEN], piv_len = 0, kid[OSCORE_CTXID_LEN], kid_len = 0,
-        ctx_id[OSCORE_IDCTX_LEN], ctx_id_len = 0, nonce[OSCORE_AEAD_NONCE_LEN],
-                                 AAD[OSCORE_AAD_MAX_LEN], AAD_len = 0;
+    uint8_t piv[OSCORE_PIV_LEN],
+      piv_len = 0, kid[OSCORE_CTXID_LEN], kid_len = 0, ctx_id[OSCORE_IDCTX_LEN],
+      ctx_id_len = 0, nonce[OSCORE_AEAD_NONCE_LEN], AAD[OSCORE_AAD_MAX_LEN],
+      AAD_len = 0;
 
     /* If CoAP message is request */
     if ((coap_pkt->code >= OC_GET && coap_pkt->code <= OC_DELETE)
@@ -942,11 +938,13 @@ oc_oscore_send_message(oc_message_t *msg)
     /* Set the OSCORE option */
     if ((coap_pkt->code >= OC_GET && coap_pkt->code <= OC_DELETE)) {
       // requests encode the PIV
-      coap_set_header_oscore(coap_pkt, piv, piv_len, kid, kid_len, ctx_id, ctx_id_len);
+      coap_set_header_oscore(coap_pkt, piv, piv_len, kid, kid_len, ctx_id,
+                             ctx_id_len);
     } else {
       // responses use the (cached) piv of the matching request, stored in the
       // ep/clientcb
-      coap_set_header_oscore(coap_pkt, NULL, 0, kid, kid_len, ctx_id, ctx_id_len);
+      coap_set_header_oscore(coap_pkt, NULL, 0, kid, kid_len, ctx_id,
+                             ctx_id_len);
     }
 
     /* Reflect the Observe option (if present in the CoAP packet) */

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -168,8 +168,58 @@ oc_oscore_recv_message(oc_message_t *message)
       OC_LOGbytes(oscore_pkt->kid, oscore_pkt->kid_len);
       OC_DBG_OSCORE("### searching for OSCORE context by kid ###");
       oscore_ctx =
-        oc_oscore_find_context_by_kid(oscore_ctx, message->endpoint.device,
-                                      oscore_pkt->kid, oscore_pkt->kid_len);
+        oc_oscore_find_context_by_kid_idctx(oscore_ctx, message->endpoint.device,
+                                      oscore_pkt->kid, oscore_pkt->kid_len, oscore_pkt->kid_ctx, oscore_pkt->kid_ctx_len);
+      
+      if (!oscore_ctx)
+      {
+        // we do not have a cached context, so we have to make one
+
+        // find auth/at entry with corresponding kid
+        int idx = oc_core_find_at_entry_with_osc_id(0, oscore_pkt->kid, oscore_pkt->kid_len);
+        if (idx == -1)
+        {
+          OC_ERR(
+            "***Could not find Access Token matching KID, returning UNAUTHORIZED***");
+          oscore_send_error(oscore_pkt, UNAUTHORIZED_4_01, &message->endpoint);
+          goto oscore_recv_error;
+        }
+        oc_auth_at_t *at_entry = oc_get_auth_at_entry(0, idx);
+
+        // create oscore recipient context from that entry
+        oscore_ctx = oc_oscore_add_context(0,
+          oc_string(at_entry->osc_rid), /* sender id (empty string) */
+          oc_byte_string_len(at_entry->osc_rid), /* sender id len (ought to be 0)*/
+          oc_string(at_entry->osc_id), /* recipient id */
+          oc_byte_string_len(at_entry->osc_id), /* recipient id len */
+          0, "desc",
+          oc_string(at_entry->osc_ms),
+          oc_byte_string_len(at_entry->osc_ms),
+          oscore_pkt->kid_ctx,
+          oscore_pkt->kid_ctx_len, idx, false);
+
+        // if context is null, free one & try adding again
+        if (!oscore_ctx)
+        {
+          oscore_ctx = oc_oscore_add_context(0,
+            oc_string(at_entry->osc_rid), /* sender id (empty string) */
+            oc_byte_string_len(at_entry->osc_rid), /* sender id len (ought to be 0)*/
+            oc_string(at_entry->osc_id), /* recipient id */
+            oc_byte_string_len(at_entry->osc_id), /* recipient id len */
+            0, "desc",
+            oc_string(at_entry->osc_ms),
+            oc_byte_string_len(at_entry->osc_ms),
+            oscore_pkt->kid_ctx,
+            oscore_pkt->kid_ctx_len, idx, false);
+          if (!oscore_ctx)
+          {
+            OC_ERR("***Could not create oscore recipient context!***");
+            oscore_send_error(oscore_pkt, UNAUTHORIZED_4_01, &message->endpoint);
+            goto oscore_recv_error;
+
+          }
+        }
+      }
     } else {
       /* If message is response */
       if (oscore_pkt->code > OC_FETCH) {


### PR DESCRIPTION
This PR lets the stack create recipient contexts dynamically, using the key ID & master secret from the auth/at entry, but taking the context ID from received requests.

Since we cannot store the security context for every sender in memory (we may have hundreds of them) this PR implements a Least Recently Used cache for recipient contexts only. Infrequently used contexts will be freed to make room for more useful ones. This has the advantage of not requiring extra flash / ram when talking to multiple recipients, the amount used is constant.

Tested with the spake test client in the stack, with and without a contextid in the request. Will do a bit more testing and mark as ready for review.