### PR TITLE
Fix vulnerability in separate responses due to nonce reuse

### DIFF
--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1726,7 +1726,8 @@ oc_ri_invoke_client_cb(void *response, oc_client_cb_t *cb,
 #if defined(OC_OSCORE)
   if (client_response.observe_option > 1) {
     uint64_t notification_num = 0;
-    oscore_read_piv(endpoint->request_piv, endpoint->request_piv_len, &notification_num);
+    oscore_read_piv(endpoint->request_piv, endpoint->request_piv_len,
+                    &notification_num);
     if (notification_num < cb->notification_num) {
       return true;
     }

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1726,7 +1726,7 @@ oc_ri_invoke_client_cb(void *response, oc_client_cb_t *cb,
 #if defined(OC_OSCORE)
   if (client_response.observe_option > 1) {
     uint64_t notification_num = 0;
-    oscore_read_piv(endpoint->piv, endpoint->piv_len, &notification_num);
+    oscore_read_piv(endpoint->request_piv, endpoint->request_piv_len, &notification_num);
     if (notification_num < cb->notification_num) {
       return true;
     }

--- a/include/oc_endpoint.h
+++ b/include/oc_endpoint.h
@@ -104,7 +104,7 @@ typedef struct oc_endpoint_t
   uint8_t kid[OSCORE_CTXID_LEN];
   uint8_t kid_ctx_len;
   uint8_t kid_ctx[OSCORE_IDCTX_LEN];
-  //bool rx_msg_is_response;
+  // bool rx_msg_is_response;
 } oc_endpoint_t;
 
 #define oc_make_ipv4_endpoint(__name__, __flags__, __port__, ...)              \

--- a/include/oc_endpoint.h
+++ b/include/oc_endpoint.h
@@ -104,7 +104,7 @@ typedef struct oc_endpoint_t
   uint8_t kid[OSCORE_CTXID_LEN];
   uint8_t kid_ctx_len;
   uint8_t kid_ctx[OSCORE_IDCTX_LEN];
-  bool rx_msg_is_response;
+  //bool rx_msg_is_response;
 } oc_endpoint_t;
 
 #define oc_make_ipv4_endpoint(__name__, __flags__, __port__, ...)              \

--- a/include/oc_endpoint.h
+++ b/include/oc_endpoint.h
@@ -98,8 +98,8 @@ typedef struct oc_endpoint_t
     auth_at_index; /**< auth at index +1 [1-max_indexes], 0 == error.
                     * Used for matching oscore context of response to request.
                     * Used for upper layers to check access interfaces. */
-  uint8_t piv[OSCORE_PIV_LEN]; /**< OSCORE partial iv */
-  uint8_t piv_len;             /**< OSCORE partial iv length */
+  uint8_t request_piv[OSCORE_PIV_LEN]; /**< OSCORE partial iv */
+  uint8_t request_piv_len;             /**< OSCORE partial iv length */
   uint8_t kid_len;
   uint8_t kid[OSCORE_CTXID_LEN];
   uint8_t kid_ctx_len;

--- a/include/oc_endpoint.h
+++ b/include/oc_endpoint.h
@@ -104,6 +104,7 @@ typedef struct oc_endpoint_t
   uint8_t kid[OSCORE_CTXID_LEN];
   uint8_t kid_ctx_len;
   uint8_t kid_ctx[OSCORE_IDCTX_LEN];
+  bool rx_msg_is_response;
 } oc_endpoint_t;
 
 #define oc_make_ipv4_endpoint(__name__, __flags__, __port__, ...)              \

--- a/messaging/coap/coap.c
+++ b/messaging/coap/coap.c
@@ -1130,7 +1130,7 @@ coap_oscore_serialize_message(void *packet, uint8_t *buffer, bool inner,
   }
 
   /* empty packet, don't need to do more stuff */
-  if (outer && !coap_pkt->code) {
+  if (outer && !coap_pkt->code && coap_pkt->token_len == 0) {
     OC_DBG("Done serializing empty message at %p-", coap_pkt->buffer);
     return token_location;
   } else if (outer) {

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -880,7 +880,7 @@ coap_receive(oc_message_t *msg)
 #endif /* OC_CLIENT */
 
       if (message->type == COAP_TYPE_CON) {
-        coap_send_empty_response(COAP_TYPE_ACK, message->mid, NULL, 0, 0,
+        coap_send_empty_response(COAP_TYPE_ACK, message->mid, message->token, message->token_len, 0,
                                  &msg->endpoint);
       } else if (message->type == COAP_TYPE_ACK) {
       } else if (message->type == COAP_TYPE_RST) {

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -486,7 +486,8 @@ coap_receive(oc_message_t *msg)
         oc_new_byte_string(&kid, msg->endpoint.kid, msg->endpoint.kid_len);
         oc_new_byte_string(&kid_ctx, msg->endpoint.kid_ctx,
                            msg->endpoint.kid_ctx_len);
-        oscore_read_piv(msg->endpoint.request_piv, msg->endpoint.request_piv_len, &ssn);
+        oscore_read_piv(msg->endpoint.request_piv,
+                        msg->endpoint.request_piv_len, &ssn);
 
         client_is_sync = oc_replay_check_client(ssn, kid, kid_ctx);
       }
@@ -880,8 +881,8 @@ coap_receive(oc_message_t *msg)
 #endif /* OC_CLIENT */
 
       if (message->type == COAP_TYPE_CON) {
-        coap_send_empty_response(COAP_TYPE_ACK, message->mid, message->token, message->token_len, 0,
-                                 &msg->endpoint);
+        coap_send_empty_response(COAP_TYPE_ACK, message->mid, message->token,
+                                 message->token_len, 0, &msg->endpoint);
       } else if (message->type == COAP_TYPE_ACK) {
       } else if (message->type == COAP_TYPE_RST) {
 #ifdef OC_SERVER

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -486,7 +486,7 @@ coap_receive(oc_message_t *msg)
         oc_new_byte_string(&kid, msg->endpoint.kid, msg->endpoint.kid_len);
         oc_new_byte_string(&kid_ctx, msg->endpoint.kid_ctx,
                            msg->endpoint.kid_ctx_len);
-        oscore_read_piv(msg->endpoint.piv, msg->endpoint.piv_len, &ssn);
+        oscore_read_piv(msg->endpoint.request_piv, msg->endpoint.request_piv_len, &ssn);
 
         client_is_sync = oc_replay_check_client(ssn, kid, kid_ctx);
       }

--- a/messaging/coap/separate.c
+++ b/messaging/coap/separate.c
@@ -137,6 +137,9 @@ coap_separate_accept(void *request, oc_separate_response_t *separate_response,
     coap_packet_t ack[1];
     /* ACK with empty code (0) */
     coap_udp_init_message(ack, COAP_TYPE_ACK, 0, coap_req->mid);
+    ack->token_len = separate_store->token_len;
+    memcpy(ack->token, separate_store->token, ack->token_len);
+
     oc_message_t *message = oc_internal_allocate_outgoing_message();
     if (message != NULL) {
       memcpy(&message->endpoint, endpoint, sizeof(oc_endpoint_t));

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -146,8 +146,8 @@ oc_oscore_find_context_by_token_mid(size_t device, uint8_t *token,
       }
     }
     if (request_piv && request_piv_len) {
-      *request_piv = t->message->endpoint.piv;
-      *request_piv_len = t->message->endpoint.piv_len;
+      *request_piv = t->message->endpoint.request_piv;
+      *request_piv_len = t->message->endpoint.request_piv_len;
     }
     // serial_number = t->message->endpoint.serial_number;
     oscore_id = t->message->endpoint.oscore_id;

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -822,10 +822,12 @@ oc_oscore_send_message(oc_message_t *msg)
       OC_DBG_OSCORE("---");
 
       /* Copy partial IV into incoming oc_message_t (*msg), if valid */
+      /*
       if (msg_valid) {
         memcpy(msg->endpoint.piv, piv, piv_len);
         msg->endpoint.piv_len = piv_len;
       }
+      */
     } else {
       /* We are dealing with a response */
 

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -309,13 +309,15 @@ oc_oscore_recv_message(oc_message_t *message)
       OC_DBG_OSCORE("---got request_piv from client callback");
       OC_LOGbytes_OSCORE(request_piv, request_piv_len);
 
-      /* If oc_message_t->endpoint.piv_len == 0 */
-      if (oscore_pkt->piv_len == 0) {
+      if (message->endpoint.request_piv_len == 0)
+      {
         /* Copy request_piv from client cb/transaction into
          * oc_message_t->endpoint */
         memcpy(message->endpoint.request_piv, request_piv, request_piv_len);
         message->endpoint.request_piv_len = request_piv_len;
+      }
 
+      if (oscore_pkt->piv_len == 0) {
         /* Compute nonce using request_piv and context->sendid */
         oc_oscore_AEAD_nonce(oscore_ctx->sendid, oscore_ctx->sendid_len,
                              request_piv, request_piv_len, oscore_ctx->commoniv,
@@ -894,6 +896,10 @@ oc_oscore_send_message(oc_message_t *msg)
       if (is_empty_ack && msg->endpoint.rx_msg_is_response)
       {
         OC_DBG_OSCORE("--- is empty ACK, using details from the request");
+        // BUG IS HERE! request_piv_len is zero, probably because this is a different endpoint
+        // than the one created for the request.
+
+        // so where piv???
         oc_oscore_compose_AAD(oscore_ctx->sendid, oscore_ctx->sendid_len,
                             message->endpoint.request_piv, message->endpoint.request_piv_len,
                             AAD, &AAD_len);

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -887,7 +887,12 @@ oc_oscore_send_message(oc_message_t *msg)
 
       }
       // AAD always uses the request PIV
-      oc_oscore_compose_AAD(oscore_ctx->recvid, oscore_ctx->recvid_len,
+      if (is_empty_ack)
+        oc_oscore_compose_AAD(oscore_ctx->sendid, oscore_ctx->sendid_len,
+                            message->endpoint.piv, message->endpoint.piv_len,
+                            AAD, &AAD_len);
+      else
+        oc_oscore_compose_AAD(oscore_ctx->recvid, oscore_ctx->recvid_len,
                             message->endpoint.piv, message->endpoint.piv_len,
                             AAD, &AAD_len);
       OC_DBG_OSCORE("---composed AAD using request piv and Recipient ID");

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -836,11 +836,21 @@ oc_oscore_send_message(oc_message_t *msg)
       }
       OC_DBG("### protecting outgoing response ###");
 
+      /* Use context->SSN as partial IV */
+      oscore_store_piv(oscore_ctx->ssn, piv, &piv_len);
+      OC_DBG_OSCORE("---using SSN as Partial IV: %lu", oscore_ctx->ssn);
+      OC_LOGbytes_OSCORE(piv, piv_len);
+      OC_DBG_OSCORE("---");
       /* Increment SSN for the original request, retransmissions use the same
        * SSN */
       coap_transaction_t *transaction =
         coap_get_transaction_by_token(coap_pkt->token, coap_pkt->token_len);
+      
       if (transaction && transaction->retrans_counter == 0)
+        increment_ssn_in_context(oscore_ctx);
+      else if (coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0)
+        increment_ssn_in_context(oscore_ctx);
+      else if (coap_pkt->type == COAP_TYPE_CON)
         increment_ssn_in_context(oscore_ctx);
       else if (!transaction)
         increment_ssn_in_context(oscore_ctx);

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -862,7 +862,7 @@ oc_oscore_send_message(oc_message_t *msg)
         // empty acks and separate responses use a new PIV
         OC_DBG_OSCORE("---piv");
         OC_LOGbytes_OSCORE(piv, piv_len);
-        oc_oscore_AEAD_nonce(oscore_ctx->recvid, oscore_ctx->recvid_len, piv,
+        oc_oscore_AEAD_nonce(oscore_ctx->sendid, oscore_ctx->sendid_len, piv,
                              piv_len, oscore_ctx->commoniv, nonce,
                              OSCORE_AEAD_NONCE_LEN);
         /* Compute nonce using partial IV and sender ID of the sender ( =

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -887,14 +887,21 @@ oc_oscore_send_message(oc_message_t *msg)
 
       }
       // AAD always uses the request PIV
-      if (is_empty_ack)
+
+      // this if should only fire when the client is sending the acknowledgement
+      // for the confirmable, separate response of the server
+      if (is_empty_ack && false)
+      {
         oc_oscore_compose_AAD(oscore_ctx->sendid, oscore_ctx->sendid_len,
                             message->endpoint.piv, message->endpoint.piv_len,
                             AAD, &AAD_len);
+      }
       else
+      {
         oc_oscore_compose_AAD(oscore_ctx->recvid, oscore_ctx->recvid_len,
                             message->endpoint.piv, message->endpoint.piv_len,
                             AAD, &AAD_len);
+      }
       OC_DBG_OSCORE("---composed AAD using request piv and Recipient ID");
       OC_LOGbytes_OSCORE(AAD, AAD_len);
 

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -893,6 +893,7 @@ oc_oscore_send_message(oc_message_t *msg)
       // for the confirmable, separate response of the server
       if (is_empty_ack && msg->endpoint.rx_msg_is_response)
       {
+        OC_DBG_OSCORE("--- is empty ACK, using details from the request");
         oc_oscore_compose_AAD(oscore_ctx->sendid, oscore_ctx->sendid_len,
                             message->endpoint.request_piv, message->endpoint.request_piv_len,
                             AAD, &AAD_len);

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -836,13 +836,6 @@ oc_oscore_send_message(oc_message_t *msg)
         msg->endpoint.request_piv_len = piv_len;
       }
     } else {
-      /* We are dealing with a response */
-
-      /* Request was not protected by OSCORE */
-      if (message->endpoint.request_piv_len == 0) {
-        OC_DBG("request was not protected by OSCORE");
-        goto oscore_send_dispatch;
-      }
       OC_DBG("### protecting outgoing response ###");
 
       /* Use context->SSN as partial IV */

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -870,8 +870,6 @@ oc_oscore_send_message(oc_message_t *msg)
           "---computed AEAD nonce using new Partial IV (SSN) and Sender ID");
         OC_LOGbytes_OSCORE(nonce, OSCORE_AEAD_NONCE_LEN);
 
-        oc_oscore_compose_AAD(oscore_ctx->recvid, oscore_ctx->recvid_len, piv,
-                              piv_len, AAD, &AAD_len);
       } else {
         // other responses reuse the PIV from the request
         OC_DBG_OSCORE("---request_piv");
@@ -886,12 +884,12 @@ oc_oscore_send_message(oc_message_t *msg)
           "---computed AEAD nonce using new Partial IV (SSN) and Sender ID");
         OC_LOGbytes_OSCORE(nonce, OSCORE_AEAD_NONCE_LEN);
 
-        oc_oscore_compose_AAD(oscore_ctx->recvid, oscore_ctx->recvid_len,
-                              message->endpoint.piv, message->endpoint.piv_len,
-                              AAD, &AAD_len);
       }
-
-      OC_DBG_OSCORE("---composed AAD using piv and Recipient ID");
+      // AAD always uses the request PIV
+      oc_oscore_compose_AAD(oscore_ctx->recvid, oscore_ctx->recvid_len,
+                            message->endpoint.piv, message->endpoint.piv_len,
+                            AAD, &AAD_len);
+      OC_DBG_OSCORE("---composed AAD using request piv and Recipient ID");
       OC_LOGbytes_OSCORE(AAD, AAD_len);
 
       /* Copy partial IV into incoming oc_message_t (*msg), if valid */

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -283,16 +283,16 @@ oc_oscore_recv_message(oc_message_t *message)
         OC_LOGbytes_OSCORE(AAD, AAD_len);
       }
 
+      OC_DBG_OSCORE("---got Partial IV from incoming message");
+      OC_LOGbytes_OSCORE(oscore_pkt->piv, oscore_pkt->piv_len);
+
       /* Copy received piv into oc_message_t->endpoint for requests */
       if (oscore_pkt->code >= OC_GET && oscore_pkt->code <= OC_DELETE)
       {
         memcpy(message->endpoint.request_piv, oscore_pkt->piv, oscore_pkt->piv_len);
         message->endpoint.request_piv_len = oscore_pkt->piv_len;
+        OC_DBG_OSCORE("---  Caching PIV for later use...");
       }
-
-      OC_DBG_OSCORE("---got Partial IV from incoming message");
-      OC_DBG_OSCORE("---  Caching PIV for later use...");
-      OC_LOGbytes_OSCORE(message->endpoint.request_piv, message->endpoint.request_piv_len);
 
       /* Compute nonce using received piv and context->recvid */
       oc_oscore_AEAD_nonce(oscore_ctx->recvid, oscore_ctx->recvid_len,
@@ -310,7 +310,7 @@ oc_oscore_recv_message(oc_message_t *message)
       OC_LOGbytes_OSCORE(request_piv, request_piv_len);
 
       /* If oc_message_t->endpoint.piv_len == 0 */
-      if (message->endpoint.request_piv_len == 0) {
+      if (oscore_pkt->piv_len == 0) {
         /* Copy request_piv from client cb/transaction into
          * oc_message_t->endpoint */
         memcpy(message->endpoint.request_piv, request_piv, request_piv_len);

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -913,8 +913,8 @@ oc_oscore_send_message(oc_message_t *msg)
       OC_DBG_OSCORE("---composed AAD using request piv and Recipient ID");
       OC_LOGbytes_OSCORE(AAD, AAD_len);
 
-      /* Copy partial IV into incoming oc_message_t (*msg), if valid */
-      if (msg_valid) {
+      /* Copy partial IV into incoming oc_message_t (*msg), if valid and if message is request */
+      if (msg_valid && coap_pkt->code >= OC_GET && coap_pkt->code <= OC_DELETE) {
         memcpy(msg->endpoint.request_piv, piv, piv_len);
         msg->endpoint.request_piv_len = piv_len;
         OC_DBG_OSCORE("--- Caching PIV for later use...");

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -159,6 +159,11 @@ oc_oscore_recv_message(oc_message_t *message)
       }
     }
 
+    if (oscore_pkt->code >= OC_GET && oscore_pkt->code <= OC_DELETE)
+      message->endpoint.rx_msg_is_response = false;
+    else
+      message->endpoint.rx_msg_is_response = true;
+
     uint8_t *request_piv = NULL, request_piv_len = 0;
 
     /* If OSCORE packet contains kid... */
@@ -890,7 +895,7 @@ oc_oscore_send_message(oc_message_t *msg)
 
       // this if should only fire when the client is sending the acknowledgement
       // for the confirmable, separate response of the server
-      if (is_empty_ack && false)
+      if (is_empty_ack && msg->endpoint.rx_msg_is_response)
       {
         oc_oscore_compose_AAD(oscore_ctx->sendid, oscore_ctx->sendid_len,
                             message->endpoint.piv, message->endpoint.piv_len,

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -850,7 +850,7 @@ oc_oscore_send_message(oc_message_t *msg)
       bool is_initial_transmission =
         transaction && transaction->retrans_counter == 0;
       bool is_empty_ack =
-        coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0;
+        coap_pkt->type == COAP_TYPE_ACK && coap_pkt->code == 0;
       bool is_separate_response = coap_pkt->type == COAP_TYPE_CON;
       bool is_not_transaction = !transaction;
 
@@ -969,7 +969,7 @@ oc_oscore_send_message(oc_message_t *msg)
     bool is_request =
       coap_pkt->type == COAP_TYPE_CON && coap_pkt->type == COAP_TYPE_NON;
     bool is_empty_ack =
-      coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0;
+      coap_pkt->type == COAP_TYPE_ACK && coap_pkt->code == 0;
     bool is_separate_response = coap_pkt->type == COAP_TYPE_CON;
     /* Set the OSCORE option */
     if (is_request || is_empty_ack || is_separate_response) {

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -836,6 +836,13 @@ oc_oscore_send_message(oc_message_t *msg)
         msg->endpoint.request_piv_len = piv_len;
       }
     } else {
+      /* We are dealing with a response */
+
+      /* Request was not protected by OSCORE */
+      if (message->endpoint.request_piv_len == 0) {
+        OC_DBG("request was not protected by OSCORE");
+        goto oscore_send_dispatch;
+      }
       OC_DBG("### protecting outgoing response ###");
 
       /* Use context->SSN as partial IV */

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -904,6 +904,9 @@ oc_oscore_send_message(oc_message_t *msg)
         memcpy(ctx_id, oscore_ctx->idctx, oscore_ctx->idctx_len);
         ctx_id_len = oscore_ctx->idctx_len;
 
+        OC_DBG_OSCORE("--- Including KID:");
+        OC_LOGbytes_OSCORE(kid, kid_len);
+
         oc_oscore_compose_AAD(oscore_ctx->sendid, oscore_ctx->sendid_len,
                             message->endpoint.request_piv, message->endpoint.request_piv_len,
                             AAD, &AAD_len);

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -891,15 +891,19 @@ oc_oscore_send_message(oc_message_t *msg)
       }
       // AAD always uses the request PIV
 
-      // this if should only fire when the client is sending the acknowledgement
-      // for the confirmable, separate response of the server
       if (is_empty_ack && msg->endpoint.rx_msg_is_response)
       {
+        // only fires when the client is sending the acknowledgement
+        // for the confirmable, separate response of the server
         OC_DBG_OSCORE("--- is empty ACK, using details from the request");
-        // BUG IS HERE! request_piv_len is zero, probably because this is a different endpoint
-        // than the one created for the request.
+        // We have already sent an ACK for the original request, so the transaction 
+        // is gone and the other side cannot find the keying material. so for this
+        // message only we include it again.
+        memcpy(kid, oscore_ctx->sendid, oscore_ctx->sendid_len);
+        kid_len = oscore_ctx->sendid_len;
+        memcpy(ctx_id, oscore_ctx->idctx, oscore_ctx->idctx_len);
+        ctx_id_len = oscore_ctx->idctx_len;
 
-        // so where piv???
         oc_oscore_compose_AAD(oscore_ctx->sendid, oscore_ctx->sendid_len,
                             message->endpoint.request_piv, message->endpoint.request_piv_len,
                             AAD, &AAD_len);

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -846,32 +846,30 @@ oc_oscore_send_message(oc_message_t *msg)
       coap_transaction_t *transaction =
         coap_get_transaction_by_token(coap_pkt->token, coap_pkt->token_len);
 
-      bool is_initial_transmission = transaction && transaction->retrans_counter == 0;
-      bool is_empty_ack            =  coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0;
-      bool is_separate_response    = coap_pkt->type == COAP_TYPE_CON;
+      bool is_initial_transmission =
+        transaction && transaction->retrans_counter == 0;
+      bool is_empty_ack =
+        coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0;
+      bool is_separate_response = coap_pkt->type == COAP_TYPE_CON;
       bool is_not_transaction = !transaction;
 
-      if  (is_initial_transmission
-        || is_empty_ack
-        || is_separate_response
-        || is_not_transaction)
+      if (is_initial_transmission || is_empty_ack || is_separate_response ||
+          is_not_transaction)
         increment_ssn_in_context(oscore_ctx);
 
-      if (is_empty_ack || is_separate_response)
-      {
+      if (is_empty_ack || is_separate_response) {
         // empty acks and separate responses use a new PIV
-        oc_oscore_AEAD_nonce(oscore_ctx->recvid, oscore_ctx->recvid_len,
-                            piv, piv_len,
-                            oscore_ctx->commoniv, nonce, OSCORE_AEAD_NONCE_LEN);
-      }
-      else
-      {
+        oc_oscore_AEAD_nonce(oscore_ctx->recvid, oscore_ctx->recvid_len, piv,
+                             piv_len, oscore_ctx->commoniv, nonce,
+                             OSCORE_AEAD_NONCE_LEN);
+      } else {
         // other responses reuse the PIV from the request
         oc_oscore_AEAD_nonce(oscore_ctx->recvid, oscore_ctx->recvid_len,
-                            message->endpoint.piv, message->endpoint.piv_len,
-                            oscore_ctx->commoniv, nonce, OSCORE_AEAD_NONCE_LEN);
+                             message->endpoint.piv, message->endpoint.piv_len,
+                             oscore_ctx->commoniv, nonce,
+                             OSCORE_AEAD_NONCE_LEN);
       }
-      
+
       /* Compute nonce using partial IV and sender ID of the sender ( = receiver
        * ID )*/
       OC_DBG_OSCORE(
@@ -959,16 +957,18 @@ oc_oscore_send_message(oc_message_t *msg)
       coap_set_header_max_age(coap_pkt, 0);
     }
 
-    bool is_request = coap_pkt->type == COAP_TYPE_CON && coap_pkt->type == COAP_TYPE_NON;
-    bool is_empty_ack            =  coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0;
-    bool is_separate_response    = coap_pkt->type == COAP_TYPE_CON;
+    bool is_request =
+      coap_pkt->type == COAP_TYPE_CON && coap_pkt->type == COAP_TYPE_NON;
+    bool is_empty_ack =
+      coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0;
+    bool is_separate_response = coap_pkt->type == COAP_TYPE_CON;
     /* Set the OSCORE option */
     if (is_request || is_empty_ack || is_separate_response) {
       coap_set_header_oscore(coap_pkt, piv, piv_len, kid, kid_len, ctx_id,
                              ctx_id_len);
     } else {
-      // other responses use the (cached) piv of the matching request, stored in the
-      // ep/clientcb
+      // other responses use the (cached) piv of the matching request, stored in
+      // the ep/clientcb
       coap_set_header_oscore(coap_pkt, NULL, 0, kid, kid_len, ctx_id,
                              ctx_id_len);
     }

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -838,7 +838,7 @@ oc_oscore_send_message(oc_message_t *msg)
 
       /* Use context->SSN as partial IV */
       oscore_store_piv(oscore_ctx->ssn, piv, &piv_len);
-      OC_DBG_OSCORE("---using SSN as Partial IV: %lu", oscore_ctx->ssn);
+      OC_DBG_OSCORE("---using SSN as Partial IV");
       OC_LOGbytes_OSCORE(piv, piv_len);
       OC_DBG_OSCORE("---");
       /* Increment SSN for the original request, retransmissions use the same
@@ -846,18 +846,16 @@ oc_oscore_send_message(oc_message_t *msg)
       coap_transaction_t *transaction =
         coap_get_transaction_by_token(coap_pkt->token, coap_pkt->token_len);
 
-      {
-        bool is_initial_transmission = transaction && transaction->retrans_counter == 0;
-        bool is_empty_ack            =  coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0;
-        bool is_separate_response    = coap_pkt->type == COAP_TYPE_CON;
-        bool is_not_transaction = !transaction;
+      bool is_initial_transmission = transaction && transaction->retrans_counter == 0;
+      bool is_empty_ack            =  coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0;
+      bool is_separate_response    = coap_pkt->type == COAP_TYPE_CON;
+      bool is_not_transaction = !transaction;
 
-        if  (is_initial_transmission
-          || is_empty_ack
-          || is_separate_response
-          || is_not_transaction)
-          increment_ssn_in_context(oscore_ctx);
-      }
+      if  (is_initial_transmission
+        || is_empty_ack
+        || is_separate_response
+        || is_not_transaction)
+        increment_ssn_in_context(oscore_ctx);
 
       /* Compute nonce using partial IV and sender ID of the sender ( = receiver
        * ID )*/

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -283,6 +283,7 @@ oc_oscore_recv_message(oc_message_t *message)
       message->endpoint.piv_len = oscore_pkt->piv_len;
 
       OC_DBG_OSCORE("---got Partial IV from incoming message");
+      OC_DBG_OSCORE("---  Caching PIV for later use...");
       OC_LOGbytes_OSCORE(message->endpoint.piv, message->endpoint.piv_len);
 
       /* Compute nonce using received piv and context->recvid */
@@ -893,12 +894,12 @@ oc_oscore_send_message(oc_message_t *msg)
       OC_LOGbytes_OSCORE(AAD, AAD_len);
 
       /* Copy partial IV into incoming oc_message_t (*msg), if valid */
-      /*
       if (msg_valid) {
         memcpy(msg->endpoint.piv, piv, piv_len);
         msg->endpoint.piv_len = piv_len;
+        OC_DBG_OSCORE("--- Caching PIV for later use...");
+        OC_LOGbytes_OSCORE(msg->endpoint.piv, msg->endpoint.piv_len);
       }
-      */
     }
 
     /* Move CoAP payload to offset 2*COAP_MAX_HEADER_SIZE to accommodate for

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -822,12 +822,10 @@ oc_oscore_send_message(oc_message_t *msg)
       OC_DBG_OSCORE("---");
 
       /* Copy partial IV into incoming oc_message_t (*msg), if valid */
-      /*
       if (msg_valid) {
         memcpy(msg->endpoint.piv, piv, piv_len);
         msg->endpoint.piv_len = piv_len;
       }
-      */
     } else {
       /* We are dealing with a response */
 
@@ -895,10 +893,12 @@ oc_oscore_send_message(oc_message_t *msg)
       OC_LOGbytes_OSCORE(AAD, AAD_len);
 
       /* Copy partial IV into incoming oc_message_t (*msg), if valid */
+      /*
       if (msg_valid) {
         memcpy(msg->endpoint.piv, piv, piv_len);
         msg->endpoint.piv_len = piv_len;
       }
+      */
     }
 
     /* Move CoAP payload to offset 2*COAP_MAX_HEADER_SIZE to accommodate for

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -845,15 +845,19 @@ oc_oscore_send_message(oc_message_t *msg)
        * SSN */
       coap_transaction_t *transaction =
         coap_get_transaction_by_token(coap_pkt->token, coap_pkt->token_len);
-      
-      if (transaction && transaction->retrans_counter == 0)
-        increment_ssn_in_context(oscore_ctx);
-      else if (coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0)
-        increment_ssn_in_context(oscore_ctx);
-      else if (coap_pkt->type == COAP_TYPE_CON)
-        increment_ssn_in_context(oscore_ctx);
-      else if (!transaction)
-        increment_ssn_in_context(oscore_ctx);
+
+      {
+        bool is_initial_transmission = transaction && transaction->retrans_counter == 0;
+        bool is_empty_ack            =  coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0;
+        bool is_separate_response    = coap_pkt->type == COAP_TYPE_CON;
+        bool is_not_transaction = !transaction;
+
+        if  (is_initial_transmission
+          || is_empty_ack
+          || is_separate_response
+          || is_not_transaction)
+          increment_ssn_in_context(oscore_ctx);
+      }
 
       /* Compute nonce using partial IV and sender ID of the sender ( = receiver
        * ID )*/
@@ -946,13 +950,15 @@ oc_oscore_send_message(oc_message_t *msg)
       coap_set_header_max_age(coap_pkt, 0);
     }
 
+    bool is_request = coap_pkt->type == COAP_TYPE_CON && coap_pkt->type == COAP_TYPE_NON;
+    bool is_empty_ack            =  coap_pkt->type == COAP_TYPE_ACK && coap_pkt->token_len == 0;
+    bool is_separate_response    = coap_pkt->type == COAP_TYPE_CON;
     /* Set the OSCORE option */
-    if ((coap_pkt->code >= OC_GET && coap_pkt->code <= OC_DELETE)) {
-      // requests encode the PIV
+    if (is_request || is_empty_ack || is_separate_response) {
       coap_set_header_oscore(coap_pkt, piv, piv_len, kid, kid_len, ctx_id,
                              ctx_id_len);
     } else {
-      // responses use the (cached) piv of the matching request, stored in the
+      // other responses use the (cached) piv of the matching request, stored in the
       // ep/clientcb
       coap_set_header_oscore(coap_pkt, NULL, 0, kid, kid_len, ctx_id,
                              ctx_id_len);

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -902,6 +902,9 @@ oc_oscore_send_message(oc_message_t *msg)
       }
     }
 
+    // store the inner CoAP code
+    uint8_t inner_code = coap_pkt->code;
+
     /* Move CoAP payload to offset 2*COAP_MAX_HEADER_SIZE to accommodate for
        Outer+Inner CoAP options in the OSCORE packet.
     */
@@ -969,7 +972,7 @@ oc_oscore_send_message(oc_message_t *msg)
     bool is_request =
       coap_pkt->type == COAP_TYPE_CON && coap_pkt->type == COAP_TYPE_NON;
     bool is_empty_ack =
-      coap_pkt->type == COAP_TYPE_ACK && coap_pkt->code == 0;
+      coap_pkt->type == COAP_TYPE_ACK && inner_code == 0;
     bool is_separate_response = coap_pkt->type == COAP_TYPE_CON;
     /* Set the OSCORE option */
     if (is_request || is_empty_ack || is_separate_response) {

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -864,15 +864,14 @@ oc_oscore_send_message(oc_message_t *msg)
         oc_oscore_AEAD_nonce(oscore_ctx->recvid, oscore_ctx->recvid_len, piv,
                              piv_len, oscore_ctx->commoniv, nonce,
                              OSCORE_AEAD_NONCE_LEN);
-        /* Compute nonce using partial IV and sender ID of the sender ( = receiver
-        * ID )*/
+        /* Compute nonce using partial IV and sender ID of the sender ( =
+         * receiver ID )*/
         OC_DBG_OSCORE(
           "---computed AEAD nonce using new Partial IV (SSN) and Sender ID");
         OC_LOGbytes_OSCORE(nonce, OSCORE_AEAD_NONCE_LEN);
 
-        oc_oscore_compose_AAD(oscore_ctx->recvid, oscore_ctx->recvid_len,
-                              piv, piv_len,
-                              AAD, &AAD_len);
+        oc_oscore_compose_AAD(oscore_ctx->recvid, oscore_ctx->recvid_len, piv,
+                              piv_len, AAD, &AAD_len);
       } else {
         // other responses reuse the PIV from the request
         OC_DBG_OSCORE("---request_piv");
@@ -881,8 +880,8 @@ oc_oscore_send_message(oc_message_t *msg)
                              message->endpoint.piv, message->endpoint.piv_len,
                              oscore_ctx->commoniv, nonce,
                              OSCORE_AEAD_NONCE_LEN);
-        /* Compute nonce using partial IV and sender ID of the sender ( = receiver
-        * ID )*/
+        /* Compute nonce using partial IV and sender ID of the sender ( =
+         * receiver ID )*/
         OC_DBG_OSCORE(
           "---computed AEAD nonce using new Partial IV (SSN) and Sender ID");
         OC_LOGbytes_OSCORE(nonce, OSCORE_AEAD_NONCE_LEN);


### PR DESCRIPTION
This pull request fixes a security vulnerability that allows an attacker to decrypt the start of the plaintext of every single OSCORE encrypted separate response.

![image](https://github.com/KNX-IOT/KNX-IOT-STACK/assets/24615474/78eae073-456e-4a4a-acbf-e22f41e0f97b)
This is a capture of the stack using separate responses alongside OSCORE encryption. The messages with no key ID & repeated Partial IVs end up reusing the AEAD nonce. Since they are consecutive & the first message is very predictable (it is always an empty ACK) this is much easier to exploit than the nonce reuse attacks from before we started using context IDs.

The screenshot actually shows older stack behaviour (from before #700 was merged). In the current stack the PIV is not included within separate responses, and the messages actually cannot be decrypted as the correct cached PIV can't be identified without a token (which the first ACK cannot have).

The fix is quite simple - identify the types of messages that would reuse the nonce, and then increment & transmit the PIV for those messages as well.

