### PR TITLE
Fix hostname length

### DIFF
--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -1449,7 +1449,7 @@ oc_knx_device_storage_read(size_t device_index)
 
   uint32_t ia;
   int temp_size;
-  char tempstring[20];
+  char tempstring[255];
   bool pm;
 
   PRINT("Loading Device Config from Persistent storage\n");
@@ -1472,7 +1472,7 @@ oc_knx_device_storage_read(size_t device_index)
   }
 
   /* HOST NAME */
-  temp_size = oc_storage_read(KNX_STORAGE_HOSTNAME, (uint8_t *)&tempstring, 20);
+  temp_size = oc_storage_read(KNX_STORAGE_HOSTNAME, (uint8_t *)&tempstring, 255);
   if (temp_size > 1) {
     tempstring[temp_size] = 0;
     oc_core_set_device_hostname(device_index, tempstring);

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -1472,7 +1472,8 @@ oc_knx_device_storage_read(size_t device_index)
   }
 
   /* HOST NAME */
-  temp_size = oc_storage_read(KNX_STORAGE_HOSTNAME, (uint8_t *)&tempstring, 255);
+  temp_size =
+    oc_storage_read(KNX_STORAGE_HOSTNAME, (uint8_t *)&tempstring, 255);
   if (temp_size > 1) {
     tempstring[temp_size] = 0;
     oc_core_set_device_hostname(device_index, tempstring);

--- a/api/oc_knx_p.c
+++ b/api/oc_knx_p.c
@@ -216,7 +216,7 @@ oc_core_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
     rep = rep->next;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_OK);
+  oc_send_cbor_response(request, OC_STATUS_CHANGED);
   PRINT("oc_core_p_post_handler - end\n");
 }
 


### PR DESCRIPTION
From spec: "Device hostname for DNS resolution (minimum 60 and maximum 253 characters according to [RFC1035] clause 2.3.4)."

But, from [RFC1035] clause 2.3.4: "names: 255 octets or less."

So spec needs to be updated?
yes, this was discussed on 27/10/2023