### PR TITLE
Frank eitt fix

### DIFF
--- a/api/oc_core_res.c
+++ b/api/oc_core_res.c
@@ -350,7 +350,7 @@ int
 oc_core_set_device_fwv(size_t device_index, int major, int minor, int minor2)
 {
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("device_index %d to large\n", (int)device_index);
+    OC_ERR("device_index %d too large\n", (int)device_index);
     return -1;
   }
   oc_device_info[device_index].fwv.major = major;
@@ -363,7 +363,7 @@ int
 oc_core_set_device_hwv(size_t device_index, int major, int minor, int minor2)
 {
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("device_index %d to large\n", (int)device_index);
+    OC_ERR("device_index %d too large\n", (int)device_index);
     return -1;
   }
 
@@ -377,7 +377,7 @@ int
 oc_core_set_device_ap(size_t device_index, int major, int minor, int minor2)
 {
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("device_index %d to large\n", (int)device_index);
+    OC_ERR("device_index %d too large\n", (int)device_index);
     return -1;
   }
 
@@ -391,7 +391,7 @@ int
 oc_core_set_device_mid(size_t device_index, uint32_t mid)
 {
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("device_index %d to large\n", (int)device_index);
+    OC_ERR("device_index %d too large\n", (int)device_index);
     return -1;
   }
   oc_device_info[device_index].mid = mid;
@@ -402,7 +402,7 @@ int
 oc_core_set_device_ia(size_t device_index, uint32_t ia)
 {
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("device_index %d to large\n", (int)device_index);
+    OC_ERR("device_index %d too large\n", (int)device_index);
     return -1;
   }
   oc_device_info[device_index].ia = ia;
@@ -427,7 +427,7 @@ oc_core_set_device_hwt(size_t device_index, const char *hardwaretype)
 {
   int hwt_len = 0;
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("device_index %d to large\n", (int)device_index);
+    OC_ERR("device_index %d too large\n", (int)device_index);
     return -1;
   }
   hwt_len = strlen(hardwaretype);
@@ -446,7 +446,7 @@ int
 oc_core_set_device_pm(size_t device_index, bool pm)
 {
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("  device_index %d to large\n", (int)device_index);
+    OC_ERR("  device_index %d too large\n", (int)device_index);
     return -1;
   }
 
@@ -459,7 +459,7 @@ int
 oc_core_set_device_model(size_t device_index, const char *model)
 {
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("  device_index %d to large\n", (int)device_index);
+    OC_ERR("  device_index %d too large\n", (int)device_index);
     return -1;
   }
   oc_free_string(&oc_device_info[device_index].model);
@@ -472,7 +472,7 @@ int
 oc_core_set_device_hostname(size_t device_index, const char *host_name)
 {
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("  device_index %d to large\n", (int)device_index);
+    OC_ERR("  device_index %d too large\n", (int)device_index);
     return -1;
   }
   oc_free_string(&oc_device_info[device_index].hostname);
@@ -486,7 +486,7 @@ int
 oc_core_set_device_iid(size_t device_index, uint64_t iid)
 {
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("  device_index %d to large\n", (int)device_index);
+    OC_ERR("  device_index %d too large\n", (int)device_index);
     return -1;
   }
   oc_device_info[device_index].iid = iid;
@@ -502,7 +502,7 @@ uint64_t
 oc_core_get_device_iid(size_t device_index)
 {
   if (device_index >= (int)oc_core_get_num_devices()) {
-    OC_ERR("  device_index %d to large\n", (int)device_index);
+    OC_ERR("  device_index %d too large\n", (int)device_index);
     return -1;
   }
 

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -386,7 +386,7 @@ oc_wkcore_discovery_handler(oc_request_t *request,
       */
       // if unicast & serial number is wrong, return error
       if (ep_request != 0 && ep_len > 9 &&
-        strncmp(ep_request, "knx://sn.", 9) == 0) {
+          strncmp(ep_request, "knx://sn.", 9) == 0) {
         char *ep_serialnumber = ep_request + 9;
 
         if (strncmp(oc_string(device->serialnumber), ep_serialnumber,
@@ -399,13 +399,13 @@ oc_wkcore_discovery_handler(oc_request_t *request,
           return;
         }
       } else {
-      response_length =
-        frame_sn(oc_string(device->serialnumber), device->iid, device->ia);
-      matches = 1;
+        response_length =
+          frame_sn(oc_string(device->serialnumber), device->iid, device->ia);
+        matches = 1;
 
-      oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
+        oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
 
-      PRINT(" oc_wkcore_discovery_handler PM HANDLING: OK\n");
+        PRINT(" oc_wkcore_discovery_handler PM HANDLING: OK\n");
       }
     } else {
       /* device is not in programming mode so ignore this request*/
@@ -578,7 +578,7 @@ oc_wkcore_discovery_handler(oc_request_t *request,
   } else if (request->origin && (request->origin->flags & MULTICAST) == 0) {
     oc_send_response_no_format(request, OC_STATUS_OK);
   } else {
-      oc_ignore_request(request);
+    oc_ignore_request(request);
   }
 }
 

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -312,8 +312,10 @@ oc_wkcore_discovery_handler(oc_request_t *request,
 
   PRINT("qlen %d\nflag %d\n", request->query_len, request->origin->flags);
   /* handle multicast with no queries */
-  if (request->query_len == 0 && request->origin && (request->origin->flags & MULTICAST) != 0) {
-    response_length = frame_sn(oc_string(device->serialnumber), device->iid, device->ia);
+  if (request->query_len == 0 && request->origin &&
+      (request->origin->flags & MULTICAST) != 0) {
+    response_length =
+      frame_sn(oc_string(device->serialnumber), device->iid, device->ia);
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
     return;
   }

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -310,6 +310,14 @@ oc_wkcore_discovery_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
 
+  PRINT("qlen %d\nflag %d\n", request->query_len, request->origin->flags);
+  /* handle multicast with no queries */
+  if (request->query_len == 0 && request->origin && (request->origin->flags & MULTICAST) != 0) {
+    response_length = frame_sn(oc_string(device->serialnumber), device->iid, device->ia);
+    oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
+    return;
+  }
+
   // handle query parameters: l=ps l=total
   if (check_if_query_l_exist(request, &ps_exists, &total_exists)) {
     // example : < / fp / r / ? l = total>; total = 22; ps = 5
@@ -466,7 +474,6 @@ oc_wkcore_discovery_handler(oc_request_t *request,
           response_length =
             frame_sn(oc_string(device->serialnumber), device->iid, device->ia);
           oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
-          matches = 1;
           return;
         }
       }
@@ -517,7 +524,6 @@ oc_wkcore_discovery_handler(oc_request_t *request,
       response_length =
         frame_sn(oc_string(device->serialnumber), device->iid, device->ia);
       oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
-      matches = 1;
     } else {
       oc_ignore_request(request);
     }

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -300,8 +300,6 @@ oc_wkcore_discovery_handler(oc_request_t *request,
   if (request->query_len > 0 && !query_match) {
     if (request->origin && (request->origin->flags & MULTICAST) == 0) {
       // for unicast
-      request->response->response_buffer->content_format =
-        APPLICATION_LINK_FORMAT;
       request->response->response_buffer->response_length = response_length;
       request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
     } else {
@@ -378,7 +376,8 @@ oc_wkcore_discovery_handler(oc_request_t *request,
       request->response->response_buffer->response_length = response_length;
       request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
     } else {
-      request->response->response_buffer->code = OC_IGNORE;
+      request->response->response_buffer->response_length = response_length;
+      request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
     }
     return;
   }
@@ -602,7 +601,6 @@ oc_wkcore_discovery_handler(oc_request_t *request,
     request->response->response_buffer->response_length = response_length;
     request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
   } else if (request->origin && (request->origin->flags & MULTICAST) == 0) {
-    request->response->response_buffer->content_format = APPLICATION_LINK_FORMAT;
     request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
   } else {
     request->response->response_buffer->code = OC_IGNORE;

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -310,7 +310,6 @@ oc_wkcore_discovery_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
 
-  PRINT("qlen %d\nflag %d\n", request->query_len, request->origin->flags);
   /* handle multicast with no queries */
   if (request->query_len == 0 && request->origin &&
       (request->origin->flags & MULTICAST) != 0) {

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -365,8 +365,6 @@ oc_wkcore_discovery_handler(oc_request_t *request,
     if (strncmp(d_request, "urn:knx:g.s.*", 13) == 0) {
       // Quote from EITT test 5.1.1.8: "Must fail since the response would
       // likely be excessively large"
-      request->response->response_buffer->content_format =
-        APPLICATION_LINK_FORMAT;
       request->response->response_buffer->code =
         oc_status_code(OC_STATUS_BAD_REQUEST);
       return;
@@ -424,8 +422,6 @@ oc_wkcore_discovery_handler(oc_request_t *request,
       }
     } else {
       /* device is not in programming mode so ignore this request*/
-      request->response->response_buffer->content_format =
-        APPLICATION_LINK_FORMAT;
       if (request->origin && (request->origin->flags & MULTICAST) == 0) {
         request->response->response_buffer->code =
           oc_status_code(OC_STATUS_NOT_FOUND);
@@ -599,14 +595,14 @@ oc_wkcore_discovery_handler(oc_request_t *request,
     }
   }
 
-  request->response->response_buffer->content_format = APPLICATION_LINK_FORMAT;
-
   if (matches > 0 && response_length > 0) {
     PRINT("  oc_wkcore_discovery_handler response_length %d'\n",
           (int)response_length);
+    request->response->response_buffer->content_format = APPLICATION_LINK_FORMAT;
     request->response->response_buffer->response_length = response_length;
     request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
   } else if (request->origin && (request->origin->flags & MULTICAST) == 0) {
+    request->response->response_buffer->content_format = APPLICATION_LINK_FORMAT;
     request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
   } else {
     request->response->response_buffer->code = OC_IGNORE;

--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -1270,7 +1270,7 @@ oc_core_knx_spake_post_handler(oc_request_t *request,
   // check if the state is unloaded
   size_t device_index = request->resource->device;
   if (oc_knx_lsm_state(device_index) != LSM_S_UNLOADED) {
-    PRINT(" not in unloading state\n");
+    PRINT(" not in unloaded state\n");
     oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
     return;
   }

--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -961,16 +961,11 @@ oc_core_knx_fingerprint_get_handler(oc_request_t *request,
     return;
   }
 
-  // check if the state is unloaded
+  // check if the state is loaded
   size_t device_index = request->resource->device;
   if (oc_knx_lsm_state(device_index) != LSM_S_LOADED) {
-<<<<<<< HEAD
     OC_ERR(" not in loaded state\n");
     oc_send_response_no_format(request, OC_STATUS_SERVICE_UNAVAILABLE);
-=======
-    PRINT(" not in loaded state\n");
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
->>>>>>> 3e00f7d0f414635194a9603017c0910fe8c2f78c
     return;
   }
 

--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -283,7 +283,7 @@ oc_core_knx_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
   PRINT(" invalid command\n");
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   return;
 }
 
@@ -426,7 +426,7 @@ oc_core_knx_lsm_get_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
   if (device == NULL) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
   oc_lsm_state_t lsm = oc_knx_lsm_state(device_index);
@@ -458,7 +458,7 @@ oc_core_knx_lsm_post_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
   if (device == NULL) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -510,7 +510,7 @@ oc_core_knx_lsm_post_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_lsm, knx_dot_knx, 0, "/a/lsm", OC_IF_C,
@@ -550,7 +550,7 @@ oc_core_knx_k_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
   if (device == NULL) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -901,8 +901,7 @@ oc_core_knx_k_post_handler(oc_request_t *request,
     return;
   }
   // send the response
-  // oc_send_cbor_response(request, OC_STATUS_OK);
-  oc_send_cbor_response_no_payload_size(request, OC_STATUS_OK);
+  oc_send_response_no_format(request, OC_STATUS_OK);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_dot_knx, knx_g, 0, "/.knx",
@@ -999,7 +998,7 @@ oc_core_knx_ia_post_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1042,10 +1041,9 @@ oc_core_knx_ia_post_handler(oc_request_t *request,
       knx_publish_service(oc_string(device->serialnumber), device->iid,
                           device->ia, device->pm);
     }
-    // oc_send_cbor_response(request, OC_STATUS_CHANGED);
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_CHANGED);
+    oc_send_response_no_format(request, OC_STATUS_CHANGED);
   } else {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   }
 }
 
@@ -1271,7 +1269,7 @@ oc_core_knx_spake_post_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   if (oc_knx_lsm_state(device_index) != LSM_S_UNLOADED) {
     PRINT(" not in unloaded state\n");
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1309,7 +1307,7 @@ oc_core_knx_spake_post_handler(oc_request_t *request,
   }
 
   if (valid_request == 0) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   }
   rep = request->request_payload;
 

--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -964,7 +964,7 @@ oc_core_knx_fingerprint_get_handler(oc_request_t *request,
   // check if the state is unloaded
   size_t device_index = request->resource->device;
   if (oc_knx_lsm_state(device_index) != LSM_S_LOADED) {
-    PRINT(" not in loaded state\n");
+    OC_ERR(" not in loaded state\n");
     oc_send_response_no_format(request, OC_STATUS_SERVICE_UNAVAILABLE);
     return;
   }
@@ -1277,7 +1277,7 @@ oc_core_knx_spake_post_handler(oc_request_t *request,
   // check if the state is unloaded
   size_t device_index = request->resource->device;
   if (oc_knx_lsm_state(device_index) != LSM_S_UNLOADED) {
-    PRINT(" not in unloaded state\n");
+    OC_ERR(" not in unloaded state\n");
     oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }

--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -960,6 +960,15 @@ oc_core_knx_fingerprint_get_handler(oc_request_t *request,
       oc_status_code(OC_STATUS_BAD_REQUEST);
     return;
   }
+
+  // check if the state is unloaded
+  size_t device_index = request->resource->device;
+  if (oc_knx_lsm_state(device_index) != LSM_S_LOADED) {
+    PRINT(" not in loaded state\n");
+    oc_send_response_no_format(request, OC_STATUS_SERVICE_UNAVAILABLE);
+    return;
+  }
+
   // cbor_encode_uint(&g_encoder, g_fingerprint);
   oc_rep_begin_root_object();
   oc_rep_i_set_int(root, 1, g_fingerprint);

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -1089,7 +1089,8 @@ oc_create_dev_port_resource(int resource_idx, size_t device)
   OC_DBG("oc_create_dev_port_resource\n");
   oc_core_populate_resource(resource_idx, device, "/dev/port", OC_IF_P,
                             APPLICATION_CBOR, OC_DISCOVERABLE,
-                            oc_core_dev_port_get_handler, oc_core_dev_port_put_handler, 0, 0, 0);
+                            oc_core_dev_port_get_handler,
+                            oc_core_dev_port_put_handler, 0, 0, 0);
 
   oc_core_bind_dpt_resource(resource_idx, device, "urn:knx:dpt.value2Ucount");
 }

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -457,7 +457,7 @@ oc_core_dev_hostname_get_handler(oc_request_t *request,
 
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
-  if (device != NULL && oc_string(device->hostname) != NULL) {
+  if (device != NULL) {
     oc_rep_begin_root_object();
     oc_rep_i_set_text_string(root, 1, oc_string(device->hostname));
     oc_rep_end_root_object();

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -432,7 +432,7 @@ oc_core_dev_hostname_put_handler(oc_request_t *request,
           my_hostname->cb(device_index, rep->value.string, my_hostname->data);
         }
 
-        oc_send_response_no_format(request, OC_STATUS_OK);
+        oc_send_response_no_format(request, OC_STATUS_CHANGED);
         return;
       }
     }

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -721,7 +721,7 @@ oc_core_dev_pm_put_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -743,8 +743,7 @@ oc_core_dev_pm_put_handler(oc_request_t *request,
         else
           device->pm = rep->value.boolean;
 
-        // oc_send_cbor_response(request, OC_STATUS_CHANGED);
-        oc_send_cbor_response_no_payload_size(request, OC_STATUS_CHANGED);
+        oc_send_response_no_format(request, OC_STATUS_CHANGED);
 
         knx_publish_service(oc_string(device->serialnumber), device->iid,
                             device->ia, device->pm);
@@ -755,7 +754,7 @@ oc_core_dev_pm_put_handler(oc_request_t *request,
     rep = rep->next;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_pm, dev_ipv6, 0, "/dev/pm", OC_IF_P,

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -1078,7 +1078,8 @@ oc_core_dev_port_put_handler(oc_request_t *request,
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_port, dev_mport, 0, "/dev/port",
                                      OC_IF_P, APPLICATION_CBOR, OC_DISCOVERABLE,
-                                     oc_core_dev_port_get_handler, oc_core_dev_port_put_handler, 0, 0,
+                                     oc_core_dev_port_get_handler,
+                                     oc_core_dev_port_put_handler, 0, 0,
                                      "urn:knx:dpt.value2Ucount",
                                      OC_SIZE_ZERO());
 

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -1089,7 +1089,7 @@ oc_create_dev_port_resource(int resource_idx, size_t device)
   OC_DBG("oc_create_dev_port_resource\n");
   oc_core_populate_resource(resource_idx, device, "/dev/port", OC_IF_P,
                             APPLICATION_CBOR, OC_DISCOVERABLE,
-                            oc_core_dev_port_get_handler, 0, 0, 0, 0);
+                            oc_core_dev_port_get_handler, oc_core_dev_port_put_handler, 0, 0, 0);
 
   oc_core_bind_dpt_resource(resource_idx, device, "urn:knx:dpt.value2Ucount");
 }

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -46,7 +46,7 @@ oc_core_dev_sn_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -63,14 +63,14 @@ oc_core_dev_sn_get_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_sn, dev_hwv, 0, "/dev/sn", OC_IF_D,
                                      APPLICATION_CBOR, OC_DISCOVERABLE,
                                      oc_core_dev_sn_get_handler, 0, 0, 0,
                                      "urn:knx:dpt.serNum", OC_SIZE_MANY(1),
-                                     "urn:knx:dpa:0.11")
+                                     "urn:knx:dpa:0.11");
 
 void
 oc_create_dev_sn_resource(int resource_idx, size_t device)
@@ -96,7 +96,7 @@ oc_core_dev_hwv_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
   PRINT("oc_core_dev_hwv_get_handler\n");
@@ -116,7 +116,7 @@ oc_core_dev_hwv_get_handler(oc_request_t *request,
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
   }
-  oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+  oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_hwv, dev_fwv, 0, "/dev/hwv", OC_IF_D,
@@ -146,7 +146,7 @@ oc_core_dev_fwv_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -168,7 +168,7 @@ oc_core_dev_fwv_get_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+  oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_fwv, dev_hwt, 0, "/dev/fwv", OC_IF_D,
@@ -200,7 +200,7 @@ oc_core_dev_hwt_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -213,7 +213,7 @@ oc_core_dev_hwt_get_handler(oc_request_t *request,
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
   }
-  oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+  oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_hwt, dev_model, 0, "/dev/hwt", OC_IF_D,
@@ -246,7 +246,7 @@ oc_core_dev_model_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -259,7 +259,7 @@ oc_core_dev_model_get_handler(oc_request_t *request,
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
   }
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_model, dev_ia, 0, "/dev/model",
@@ -292,7 +292,7 @@ oc_core_dev_ia_get_handler(oc_request_t *request,
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
     OC_ERR("invalid request");
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -311,7 +311,7 @@ oc_core_dev_ia_get_handler(oc_request_t *request,
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
   }
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 static void
@@ -327,7 +327,7 @@ oc_core_dev_ia_put_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -363,7 +363,7 @@ oc_core_dev_ia_put_handler(oc_request_t *request,
   }
   if (fid_set) {
     OC_ERR("fid set in request: returning error!");
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -374,10 +374,9 @@ oc_core_dev_ia_put_handler(oc_request_t *request,
       oc_init_datapoints_at_initialization();
     }
 
-    // oc_send_cbor_response(request, OC_STATUS_CHANGED);
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_CHANGED);
+    oc_send_response_no_format(request, OC_STATUS_CHANGED);
   } else {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   }
 }
 
@@ -411,7 +410,7 @@ oc_core_dev_hostname_put_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -433,15 +432,14 @@ oc_core_dev_hostname_put_handler(oc_request_t *request,
           my_hostname->cb(device_index, rep->value.string, my_hostname->data);
         }
 
-        // oc_send_cbor_response(request, OC_STATUS_OK);
-        oc_send_cbor_response_no_payload_size(request, OC_STATUS_OK);
+        oc_send_response_no_format(request, OC_STATUS_OK);
         return;
       }
     }
     rep = rep->next;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 static void
@@ -453,7 +451,7 @@ oc_core_dev_hostname_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -500,7 +498,7 @@ oc_core_dev_iid_put_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -515,8 +513,7 @@ oc_core_dev_iid_put_handler(oc_request_t *request,
         // make the value persistent
         oc_storage_write(KNX_STORAGE_IID, (uint8_t *)&rep->value.integer,
                          sizeof(uint64_t));
-        // oc_send_cbor_response(request, OC_STATUS_CHANGED);
-        oc_send_cbor_response_no_payload_size(request, OC_STATUS_CHANGED);
+        oc_send_response_no_format(request, OC_STATUS_CHANGED);
 
         // do the run time installation
         if (oc_is_device_in_runtime(device_index)) {
@@ -532,7 +529,7 @@ oc_core_dev_iid_put_handler(oc_request_t *request,
     rep = rep->next;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 static void
@@ -544,7 +541,7 @@ oc_core_dev_iid_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -559,7 +556,7 @@ oc_core_dev_iid_get_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_iid, dev_pm, 0, "/dev/iid", OC_IF_P,
@@ -596,7 +593,7 @@ oc_core_dev_ipv6_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -635,7 +632,7 @@ oc_core_dev_ipv6_get_handler(oc_request_t *request,
   oc_endpoint_t *my_ep = oc_connectivity_get_endpoints(device_index);
   if (my_ep == NULL) {
     // hmm something is wrong, no IPV6 endpoint
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   }
 
   if (check_if_query_pn_exist(request, &pn_value, &ps_value)) {
@@ -692,7 +689,7 @@ oc_core_dev_pm_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -709,7 +706,7 @@ oc_core_dev_pm_get_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 static void
@@ -810,7 +807,7 @@ oc_core_dev_dev_get_handler(oc_request_t *request,
   if (matches > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   }
 
   PRINT("oc_core_dev_dev_get_handler - end\n");
@@ -853,7 +850,7 @@ oc_core_dev_sa_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -869,7 +866,7 @@ oc_core_dev_sa_get_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_sa, dev_da, 0, "/dev/sna", OC_IF_P,
@@ -901,7 +898,7 @@ oc_core_dev_da_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -917,7 +914,7 @@ oc_core_dev_da_get_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_da, dev_fid, 0, "/dev/da", OC_IF_P,
@@ -948,7 +945,7 @@ oc_core_dev_fid_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -963,7 +960,7 @@ oc_core_dev_fid_get_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 static void
@@ -975,7 +972,7 @@ oc_core_dev_fid_put_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -989,14 +986,14 @@ oc_core_dev_fid_put_handler(oc_request_t *request,
         oc_core_set_device_fid(device_index, (uint64_t)rep->value.integer);
         uint64_t temp = (uint64_t)rep->value.integer;
         oc_storage_write(KNX_STORAGE_FID, (uint8_t *)&temp, sizeof(temp));
-        oc_send_cbor_response_no_payload_size(request, OC_STATUS_CHANGED);
+        oc_send_response_no_format(request, OC_STATUS_CHANGED);
         return;
       }
     }
     rep = rep->next;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_fid, dev_port, 0, "/dev/fid", OC_IF_P,
@@ -1029,7 +1026,7 @@ oc_core_dev_port_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1043,7 +1040,7 @@ oc_core_dev_port_get_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 static void
@@ -1055,7 +1052,7 @@ oc_core_dev_port_put_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1071,12 +1068,12 @@ oc_core_dev_port_put_handler(oc_request_t *request,
     PRINT("  oc_core_dev_port_put_handler received : %d\n",
           (int)rep->value.integer);
     device->port = (uint32_t)rep->value.integer;
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_CHANGED);
+    oc_send_response_no_format(request, OC_STATUS_CHANGED);
     oc_storage_write(KNX_STORAGE_PORT, (uint8_t *)&(rep->value.integer), 1);
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_port, dev_mport, 0, "/dev/port",
@@ -1109,7 +1106,7 @@ oc_core_dev_mport_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1123,7 +1120,7 @@ oc_core_dev_mport_get_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 static void
@@ -1135,7 +1132,7 @@ oc_core_dev_mport_put_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1151,13 +1148,12 @@ oc_core_dev_mport_put_handler(oc_request_t *request,
     PRINT("  oc_core_dev_mport_put_handler received : %d\n",
           (int)rep->value.integer);
     device->mport = (uint32_t)rep->value.integer;
-    // oc_send_cbor_response(request, OC_STATUS_CHANGED);
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_CHANGED);
+    oc_send_response_no_format(request, OC_STATUS_CHANGED);
     oc_storage_write(KNX_STORAGE_MPORT, (uint8_t *)&(rep->value.integer), 1);
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_mport, dev_mid, 0, "/dev/mport",
@@ -1232,7 +1228,7 @@ oc_core_ap_x_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1252,7 +1248,7 @@ oc_core_ap_x_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 static void
@@ -1264,7 +1260,7 @@ oc_core_ap_x_put_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1280,7 +1276,7 @@ oc_core_ap_x_put_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
     int64_t *arr = oc_int_array(rep->value.array);
     int array_size = (int)oc_int_array_size(rep->value.array);
     if (array_size != 3) {
-      oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+      oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
       return;
     }
     device->ap.major = (int)arr[0];
@@ -1290,11 +1286,11 @@ oc_core_ap_x_put_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
     // write to persistent storage
     oc_core_dump_ap(device_index);
 
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_CHANGED);
+    oc_send_response_no_format(request, OC_STATUS_CHANGED);
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(app_x, knx_spake, 0, "/ap/pv", OC_IF_P,
@@ -1332,7 +1328,7 @@ oc_core_ap_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
 
   /* check if the accept header is link-format */
   if (oc_check_accept_header(request, APPLICATION_LINK_FORMAT) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1375,7 +1371,7 @@ oc_core_ap_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
     return;
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   }
 }
 
@@ -1407,7 +1403,7 @@ oc_core_dev_mid_get_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1421,7 +1417,7 @@ oc_core_dev_mid_get_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_mid, dev, 0, "/dev/mid", OC_IF_P,

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -1078,7 +1078,7 @@ oc_core_dev_port_put_handler(oc_request_t *request,
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_port, dev_mport, 0, "/dev/port",
                                      OC_IF_P, APPLICATION_CBOR, OC_DISCOVERABLE,
-                                     oc_core_dev_port_get_handler, 0, 0, 0,
+                                     oc_core_dev_port_get_handler, oc_core_dev_port_put_handler, 0, 0,
                                      "urn:knx:dpt.value2Ucount",
                                      OC_SIZE_ZERO());
 

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -1451,7 +1451,7 @@ oc_knx_device_storage_read(size_t device_index)
   PRINT("Loading Device Config from Persistent storage\n");
 
   if (device_index >= oc_core_get_num_devices()) {
-    PRINT("device_index %d to large\n", (int)device_index);
+    PRINT("device_index %d too large\n", (int)device_index);
     return;
   }
 
@@ -1502,7 +1502,7 @@ oc_knx_device_storage_reset(size_t device_index, int reset_mode)
   uint32_t ffff = 0xffff;
 
   if (device_index >= oc_core_get_num_devices()) {
-    PRINT("oc_knx_device_storage_reset: device_index %d to large\n",
+    PRINT("oc_knx_device_storage_reset: device_index %d too large\n",
           (int)device_index);
     return;
   }
@@ -1585,7 +1585,7 @@ oc_knx_device_in_programming_mode(size_t device_index)
 {
 
   if (device_index >= oc_core_get_num_devices()) {
-    PRINT("device_index %d to large\n", (int)device_index);
+    PRINT("device_index %d too large\n", (int)device_index);
     return false;
   }
 

--- a/api/oc_knx_fb.c
+++ b/api/oc_knx_fb.c
@@ -209,7 +209,7 @@ oc_core_fb_x_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   if (matches > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   }
 
   PRINT("oc_core_fb_x_get_handler - end\n");
@@ -499,7 +499,7 @@ oc_core_fb_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   if (added) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   }
 
   PRINT("oc_core_fb_get_handler - end\n");

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -418,7 +418,7 @@ oc_core_fp_g_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   if (response_length > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_OK, 0);
+    oc_send_response_no_format(request, OC_STATUS_OK, 0);
   }
 
   PRINT("oc_core_fp_g_get_handler - end\n");
@@ -840,7 +840,7 @@ oc_core_fp_p_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   if (response_length > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_OK, 0);
+    oc_send_response_no_format(request, OC_STATUS_OK, 0);
   }
 
   PRINT("oc_core_fp_p_get_handler - end\n");
@@ -1225,7 +1225,7 @@ oc_core_fp_r_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   if (response_length > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_OK, 0);
+    oc_send_response_no_format(request, OC_STATUS_OK, 0);
   }
 
   PRINT("oc_core_fp_r_get_handler - end\n");

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -1511,8 +1511,6 @@ oc_core_fp_r_x_del_handler(oc_request_t *request,
     return;
   }
 
-  PRINT(" deleting %d\n", index);
-
   int id = oc_uri_get_wildcard_value_as_int(
     oc_string(request->resource->uri), oc_string_len(request->resource->uri),
     request->uri_path, request->uri_path_len);

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -1452,17 +1452,17 @@ oc_core_fp_r_x_get_handler(oc_request_t *request,
     oc_rep_i_set_int(root, 13, g_grt[index].grpid);
   }
   // fid - 25
-  if (g_grt[index].ia > 0) {
+  if (g_grt[index].fid > 0) {
     oc_rep_i_set_int(root, 25, g_grt[index].fid);
   }
   // iid - 26
-  if (g_grt[index].ia > 0) {
+  if (g_grt[index].iid > 0) {
     oc_rep_i_set_int(root, 26, g_grt[index].iid);
   }
   // url- 10
   oc_rep_i_set_text_string(root, 10, oc_string(g_grt[index].url));
   // at - 14
-  if (oc_string_len(g_gpt[index].at) > 0) {
+  if (oc_string_len(g_grt[index].at) > 0) {
     oc_rep_i_set_text_string(root, 14, oc_string(g_grt[index].at));
   }
   // ga - 7

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -652,7 +652,7 @@ oc_core_fp_g_x_get_handler(oc_request_t *request,
   int index = oc_core_find_index_in_group_object_table_from_id(id);
   PRINT("  id=%d index = %d\n", id, index);
   if (index == -1) {
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_NOT_FOUND);
     return;
   }
 
@@ -1047,7 +1047,7 @@ oc_core_fp_p_x_get_handler(oc_request_t *request,
   PRINT("  id:%d index = %d\n", id, index);
 
   if (index == -1) {
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_NOT_FOUND);
     return;
   }
 
@@ -1450,7 +1450,7 @@ oc_core_fp_r_x_get_handler(oc_request_t *request,
   PRINT("  id:%d index = %d\n", id, index);
 
   if (index == -1) {
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_NOT_FOUND);
     return;
   }
 

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -656,7 +656,7 @@ oc_core_fp_g_x_get_handler(oc_request_t *request,
     return;
   }
 
-  if (&g_got[index].id == -1) {
+  if (g_got[index].id == -1) {
     // it is empty
     oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -151,7 +151,7 @@ int
 oc_core_set_group_object_table(int index, oc_group_object_table_t entry)
 {
   if (index >= oc_core_get_group_object_table_total_size()) {
-    OC_ERR("index to large index:%d %d", index,
+    OC_ERR("index too large index:%d %d", index,
            oc_core_get_group_object_table_total_size());
   }
   g_got[index].cflags = entry.cflags;
@@ -2214,7 +2214,7 @@ oc_core_add_rp_entry(int index, oc_group_rp_table_t *rp_table,
                      int rp_table_size, oc_group_rp_table_t entry)
 {
   if (index >= rp_table_size) {
-    OC_ERR("recipient table index is to large: index(%d) max_size(%d)", index,
+    OC_ERR("recipient table index is too large: index(%d) max_size(%d)", index,
            rp_table_size);
   }
 

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -484,7 +484,7 @@ oc_core_fp_g_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   size_t device_index = request->resource->device;
   if (oc_knx_lsm_state(device_index) != LSM_S_LOADING) {
     OC_ERR(" not in loading state\n");
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_METHOD_NOT_ALLOWED);
     return;
   }
 
@@ -686,18 +686,18 @@ oc_core_fp_g_x_del_handler(oc_request_t *request,
   (void)iface_mask;
   PRINT("oc_core_fp_g_x_del_handler\n");
 
+  size_t device_index = request->resource->device;
+  if (oc_knx_lsm_state(device_index) != LSM_S_LOADING) {
+    OC_ERR(" not in loading state\n");
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
+    return;
+  }
+
   int id = oc_uri_get_wildcard_value_as_int(
     oc_string(request->resource->uri), oc_string_len(request->resource->uri),
     request->uri_path, request->uri_path_len);
   int index = oc_core_find_index_in_group_object_table_from_id(id);
   PRINT("  id=%d index = %d\n", id, index);
-
-  size_t device_index = request->resource->device;
-  if (oc_knx_lsm_state(device_index) != LSM_S_LOADING) {
-    PRINT(" not in loading state\n");
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-    return;
-  }
 
   PRINT(" deleting %d\n", index);
 
@@ -862,6 +862,14 @@ oc_core_fp_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
       oc_status_code(OC_STATUS_BAD_REQUEST);
     return;
   }
+
+  size_t device_index = request->resource->device;
+  if (oc_knx_lsm_state(device_index) != LSM_S_LOADING) {
+    OC_ERR(" not in loading state\n");
+    oc_send_response_no_format(request, OC_STATUS_METHOD_NOT_ALLOWED);
+    return;
+  }
+
   oc_print_rep_as_json(request->request_payload, true);
 
   int index = -1;
@@ -1103,6 +1111,13 @@ oc_core_fp_p_x_del_handler(oc_request_t *request,
   (void)iface_mask;
   PRINT("oc_core_fp_p_x_del_handler\n");
 
+  size_t device_index = request->resource->device;
+  if (oc_knx_lsm_state(device_index) != LSM_S_LOADING) {
+    OC_ERR(" not in loading state\n");
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
+    return;
+  }
+
   int id = oc_uri_get_wildcard_value_as_int(
     oc_string(request->resource->uri), oc_string_len(request->resource->uri),
     request->uri_path, request->uri_path_len);
@@ -1242,6 +1257,13 @@ oc_core_fp_r_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
     request->response->response_buffer->code =
       oc_status_code(OC_STATUS_BAD_REQUEST);
+    return;
+  }
+
+  size_t device_index = request->resource->device;
+  if (oc_knx_lsm_state(device_index) != LSM_S_LOADING) {
+    OC_ERR(" not in loading state\n");
+    oc_send_response_no_format(request, OC_STATUS_METHOD_NOT_ALLOWED);
     return;
   }
 
@@ -1481,6 +1503,15 @@ oc_core_fp_r_x_del_handler(oc_request_t *request,
   (void)data;
   (void)iface_mask;
   PRINT("oc_core_fp_r_x_del_handler\n");
+
+  size_t device_index = request->resource->device;
+  if (oc_knx_lsm_state(device_index) != LSM_S_LOADING) {
+    OC_ERR(" not in loading state\n");
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
+    return;
+  }
+
+  PRINT(" deleting %d\n", index);
 
   int id = oc_uri_get_wildcard_value_as_int(
     oc_string(request->resource->uri), oc_string_len(request->resource->uri),

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -418,7 +418,7 @@ oc_core_fp_g_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   if (response_length > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_response_no_format(request, OC_STATUS_OK, 0);
+    oc_send_response_no_format(request, OC_STATUS_OK);
   }
 
   PRINT("oc_core_fp_g_get_handler - end\n");
@@ -477,14 +477,14 @@ oc_core_fp_g_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
 
   /* check if the accept header is cbor-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
   size_t device_index = request->resource->device;
   if (oc_knx_lsm_state(device_index) != LSM_S_LOADING) {
     OC_ERR(" not in loading state\n");
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -504,7 +504,7 @@ oc_core_fp_g_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
       id = oc_table_find_id_from_rep(object);
       if (id == -1) {
         OC_ERR("  ERROR id %d", index);
-        oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
         return;
       }
       index = oc_core_find_index_in_group_object_table_from_id(id);
@@ -518,7 +518,7 @@ oc_core_fp_g_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
       index = find_empty_slot_in_group_object_table(id);
       if (index == -1) {
         OC_ERR("  ERROR index %d", index);
-        oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
         return;
       }
 
@@ -609,10 +609,10 @@ oc_core_fp_g_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   PRINT("oc_core_fp_g_post_handler status=%d - end\n", (int)status_ok);
   if (status_ok) {
     oc_knx_increase_fingerprint();
-    oc_send_cbor_response_no_payload_size(request, return_status);
+    oc_send_response_no_format(request, return_status);
     return;
   }
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_fp_g, knx_fp_g_x, 0, "/fp/g",
@@ -652,13 +652,13 @@ oc_core_fp_g_x_get_handler(oc_request_t *request,
   int index = oc_core_find_index_in_group_object_table_from_id(id);
   PRINT("  id=%d index = %d\n", id, index);
   if (index == -1) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
   if (g_got[index].id == -1) {
     // it is empty
-    oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;
   }
 
@@ -695,14 +695,14 @@ oc_core_fp_g_x_del_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   if (oc_knx_lsm_state(device_index) != LSM_S_LOADING) {
     PRINT(" not in loading state\n");
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
   PRINT(" deleting %d\n", index);
 
   if (index >= GOT_MAX_ENTRIES) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -715,7 +715,7 @@ oc_core_fp_g_x_del_handler(oc_request_t *request,
   oc_knx_increase_fingerprint();
 
   PRINT("oc_core_fp_g_x_del_handler - end\n");
-  oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);
+  oc_send_response_no_format(request, OC_STATUS_DELETED);
 }
 
 #ifdef OC_PUBLISHER_TABLE
@@ -840,7 +840,7 @@ oc_core_fp_p_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   if (response_length > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_response_no_format(request, OC_STATUS_OK, 0);
+    oc_send_response_no_format(request, OC_STATUS_OK);
   }
 
   PRINT("oc_core_fp_p_get_handler - end\n");
@@ -887,7 +887,7 @@ oc_core_fp_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
                                           oc_core_get_publisher_table_size());
       if (index == -1) {
         PRINT("  ERROR index %d\n", index);
-        oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
         return;
       }
       g_gpt[index].id = id;
@@ -997,8 +997,7 @@ oc_core_fp_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
 
   oc_knx_increase_fingerprint();
   PRINT("oc_core_fp_p_post_handler - end\n");
-  // oc_send_cbor_response(request, OC_STATUS_OK);
-  oc_send_cbor_response_no_payload_size(request, return_status);
+  oc_send_response_no_format(request, return_status);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_fp_p, knx_fp_p_x, 0, "/fp/p",
@@ -1040,13 +1039,13 @@ oc_core_fp_p_x_get_handler(oc_request_t *request,
   PRINT("  id:%d index = %d\n", id, index);
 
   if (index == -1) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
   if (g_gpt[index].id == -1) {
     /* it is empty */
-    oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;
   }
 
@@ -1111,7 +1110,7 @@ oc_core_fp_p_x_del_handler(oc_request_t *request,
     id, g_gpt, oc_core_get_publisher_table_size());
 
   if (index >= oc_core_get_publisher_table_size()) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -1131,7 +1130,7 @@ oc_core_fp_p_x_del_handler(oc_request_t *request,
   oc_knx_increase_fingerprint();
   PRINT("oc_core_fp_p_x_del_handler - end\n");
 
-  oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);
+  oc_send_response_no_format(request, OC_STATUS_DELETED);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_fp_p_x, knx_fp_r, 0, "/fp/p/*",
@@ -1225,7 +1224,7 @@ oc_core_fp_r_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   if (response_length > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_response_no_format(request, OC_STATUS_OK, 0);
+    oc_send_response_no_format(request, OC_STATUS_OK);
   }
 
   PRINT("oc_core_fp_r_get_handler - end\n");
@@ -1260,7 +1259,7 @@ oc_core_fp_r_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
       id = oc_table_find_id_from_rep(object);
       if (id == -1) {
         OC_ERR("  ERROR id %d", index);
-        oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
         return;
       }
       index = oc_core_find_index_in_rp_table_from_id(
@@ -1276,7 +1275,7 @@ oc_core_fp_r_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
                                           oc_core_get_recipient_table_size());
       if (index == -1) {
         OC_ERR("  ERROR index %d", index);
-        oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
         return;
       }
       g_grt[index].id = id;
@@ -1387,8 +1386,7 @@ oc_core_fp_r_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   oc_knx_increase_fingerprint();
 
   PRINT("oc_core_fp_r_post_handler - end\n");
-  // oc_send_cbor_response(request, OC_STATUS_OK);
-  oc_send_cbor_response_no_payload_size(request, return_status);
+  oc_send_response_no_format(request, return_status);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_fp_r, knx_fp_r_x, 0, "/fp/r",
@@ -1430,13 +1428,13 @@ oc_core_fp_r_x_get_handler(oc_request_t *request,
   PRINT("  id:%d index = %d\n", id, index);
 
   if (index == -1) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
   if (g_grt[index].id == -1) {
     // it is empty
-    oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;
   }
 
@@ -1491,7 +1489,7 @@ oc_core_fp_r_x_del_handler(oc_request_t *request,
     oc_core_find_index_in_rp_table_from_id(id, g_grt, GRT_MAX_ENTRIES);
 
   if (index >= GRT_MAX_ENTRIES) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
   PRINT("oc_core_fp_r_x_del_handler: deleting id %d at index %d\n", id, index);
@@ -1512,7 +1510,7 @@ oc_core_fp_r_x_del_handler(oc_request_t *request,
 
   PRINT("oc_core_fp_r_x_del_handler - end\n");
 
-  oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);
+  oc_send_response_no_format(request, OC_STATUS_DELETED);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_fp_r_x, knx_p, 0, "/fp/r/*",

--- a/api/oc_knx_gm.c
+++ b/api/oc_knx_gm.c
@@ -501,7 +501,7 @@ oc_core_fp_gm_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   // if (response_length > 0) {
   //   oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   // } else {
-  //   oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+  //   oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   // }
 
   PRINT("oc_core_fp_gm_get_handler - end\n");
@@ -532,7 +532,7 @@ oc_core_fp_gm_post_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   if (oc_knx_lsm_state(device_index) != LSM_S_LOADING) {
     OC_ERR(" not in loading state\n");
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
   // find the id of the entry
@@ -546,7 +546,7 @@ oc_core_fp_gm_post_handler(oc_request_t *request,
       id = oc_table_find_id_from_rep(object);
       if (id == -1) {
         OC_ERR("  ERROR id %d", id);
-        oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
         return;
       }
       // entry storage
@@ -560,7 +560,7 @@ oc_core_fp_gm_post_handler(oc_request_t *request,
         index = find_empty_group_mapping_index();
         if (index == -1) {
           PRINT("  no space left!\n");
-          oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+          oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
           return;
         }
         return_status = OC_STATUS_CREATED;
@@ -705,14 +705,14 @@ oc_core_fp_gm_x_get_handler(oc_request_t *request,
     oc_string(request->resource->uri), oc_string_len(request->resource->uri),
     request->uri_path, request->uri_path_len);
   if (value >= oc_core_get_group_mapping_table_size()) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
   // convert from [0,max-1] to [1-max]
   int index = value - 1;
   if (g_gm_entries[index].ga_len == 0) {
     // it is empty
-    oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;
   }
 
@@ -761,7 +761,7 @@ oc_core_fp_gm_x_del_handler(oc_request_t *request,
     request->uri_path, request->uri_path_len);
 
   if (value >= oc_core_get_group_mapping_table_size()) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
   int index = value - 1;
@@ -838,7 +838,7 @@ oc_core_f_netip_fra_get_handler(oc_request_t *request,
   // size_t device_index = request->resource->device;
   // oc_device_info_t *device = oc_core_get_device_info(device_index);
   // if (device == NULL) {
-  //   oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+  //   oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   //   return;
   // }
   //  Content-Format: "application/cbor"
@@ -870,7 +870,7 @@ oc_core_f_netip_fra_put_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
   if (device == NULL) {
-    oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;
   }
   oc_rep_t *rep = request->request_payload;
@@ -959,7 +959,7 @@ oc_core_f_netip_tol_get_handler(oc_request_t *request,
   // size_t device_index = request->resource->device;
   // oc_device_info_t *device = oc_core_get_device_info(device_index);
   // if (device == NULL) {
-  //   oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+  //   oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   //   return;
   // }
   //  Content-Format: "application/cbor"
@@ -990,7 +990,7 @@ oc_core_f_netip_tol_put_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
   if (device == NULL) {
-    oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;
   }
   oc_rep_t *rep = request->request_payload;
@@ -1085,7 +1085,7 @@ oc_core_f_netip_key_put_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
   if (device == NULL) {
-    oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;
   }
   oc_rep_t *rep = request->request_payload;
@@ -1176,7 +1176,7 @@ oc_core_f_netip_ttl_get_handler(oc_request_t *request,
   // size_t device_index = request->resource->device;
   // oc_device_info_t *device = oc_core_get_device_info(device_index);
   // if (device == NULL) {
-  //   oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+  //   oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   //   return;
   // }
   // Content-Format: "application/cbor"
@@ -1208,7 +1208,7 @@ oc_core_f_netip_ttl_put_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
   if (device == NULL) {
-    oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;
   }
   oc_rep_t *rep = request->request_payload;
@@ -1294,7 +1294,7 @@ oc_core_f_netip_mcast_get_handler(oc_request_t *request,
   // size_t device_index = request->resource->device;
   // oc_device_info_t *device = oc_core_get_device_info(device_index);
   // if (device == NULL) {
-  //   oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+  //   oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   //   return;
   // }
   //  Content-Format: "application/cbor"
@@ -1326,7 +1326,7 @@ oc_core_f_netip_mcast_put_handler(oc_request_t *request,
   size_t device_index = request->resource->device;
   oc_device_info_t *device = oc_core_get_device_info(device_index);
   if (device == NULL) {
-    oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;
   }
   oc_rep_t *rep = request->request_payload;
@@ -1479,7 +1479,7 @@ oc_core_f_netip_get_handler(oc_request_t *request,
   if (response_length > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   }
 
   PRINT("oc_core_f_netip_get_handler - end\n");

--- a/api/oc_knx_p.c
+++ b/api/oc_knx_p.c
@@ -115,7 +115,7 @@ oc_core_p_get_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   if (added) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   }
 
   PRINT("oc_core_p_get_handler - end\n");
@@ -166,7 +166,7 @@ oc_core_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
   if (error) {
     PRINT("oc_core_p_post_handler - end\n");
-    oc_send_cbor_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;
   }
 

--- a/api/oc_knx_p.c
+++ b/api/oc_knx_p.c
@@ -198,15 +198,17 @@ oc_core_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
                                          response_obj);
 
           new_request.request_payload = value;
-          new_request.uri_path = "/p";
-          new_request.uri_path_len = 4;
+          new_request.uri_path = oc_string(*myurl);
+          new_request.uri_path_len = oc_string_len(*myurl);
 
           const oc_resource_t *my_resource = oc_ri_get_app_resource_by_uri(
             oc_string(*myurl), oc_string_len(*myurl), device_index);
           if (my_resource) {
             // this should not be the request..
-            if (my_resource->post_handler.cb) {
-              my_resource->post_handler.cb(&new_request, iface_mask, NULL);
+            // Reason for changing POST to PUT:
+            // POST is not mandatory for parameters & datapoints
+            if (my_resource->put_handler.cb) {
+              my_resource->put_handler.cb(&new_request, iface_mask, NULL);
             }
           }
         }
@@ -216,7 +218,7 @@ oc_core_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
     rep = rep->next;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_CHANGED);
+  oc_send_response_no_format(request, OC_STATUS_CHANGED);
   PRINT("oc_core_p_post_handler - end\n");
 }
 

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -116,7 +116,7 @@ oc_core_knx_p_oscore_osndelay_put_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -134,7 +134,7 @@ oc_core_knx_p_oscore_osndelay_put_handler(oc_request_t *request,
     rep = rep->next;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_p_oscore_osndelay, knx_f_oscore, 0,
@@ -190,7 +190,7 @@ oc_core_knx_p_oscore_replwdo_put_handler(oc_request_t *request,
 
   /* check if the accept header is CBOR-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -208,7 +208,7 @@ oc_core_knx_p_oscore_replwdo_put_handler(oc_request_t *request,
     rep = rep->next;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(
@@ -261,7 +261,7 @@ oc_core_knx_f_oscore_get_handler(oc_request_t *request,
   if (matches > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   }
 }
 
@@ -311,7 +311,7 @@ oc_core_a_sen_post_handler(oc_request_t *request,
 
   /* check if the accept header is cbor-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
 
@@ -337,11 +337,10 @@ oc_core_a_sen_post_handler(oc_request_t *request,
     // renew the credentials.
     // note: this is optional for now
 
-    // oc_send_cbor_response(request, OC_STATUS_CHANGED);
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_CHANGED);
+    oc_send_response_no_format(request, OC_STATUS_CHANGED);
     return;
   }
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_a_sen, knx_auth, 0, "/a/sen",
@@ -518,7 +517,7 @@ oc_core_auth_at_get_handler(oc_request_t *request,
   if (response_length > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   }
   PRINT("oc_core_auth_at_get_handler - end\n");
 }
@@ -541,7 +540,7 @@ oc_core_auth_at_post_handler(oc_request_t *request,
 
   /* check if the accept header is cbor-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
   size_t device_index = request->resource->device;
@@ -556,7 +555,7 @@ oc_core_auth_at_post_handler(oc_request_t *request,
       oc_string_t *at = find_access_token_from_payload(object);
       if (at == NULL) {
         PRINT("  access token not found!\n");
-        oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
         return;
       }
       index = find_index_from_at(at);
@@ -568,7 +567,7 @@ oc_core_auth_at_post_handler(oc_request_t *request,
         return_status = OC_STATUS_CREATED;
         if (index == -1) {
           PRINT("  no space left!\n");
-          oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+          oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
           return;
         }
       }
@@ -764,7 +763,7 @@ oc_core_auth_at_post_handler(oc_request_t *request,
     oc_init_oscore_from_storage(device_index, false);
   }
   PRINT("oc_core_auth_at_post_handler - end\n");
-  oc_send_cbor_response_no_payload_size(request, return_status);
+  oc_send_response_no_format(request, return_status);
 }
 
 static void
@@ -785,7 +784,7 @@ oc_core_auth_at_delete_handler(oc_request_t *request,
   oc_delete_at_table(device_index);
 
   PRINT("oc_core_auth_at_delete_handler - end\n");
-  oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);
+  oc_send_response_no_format(request, OC_STATUS_DELETED);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_auth_at, knx_auth_at_x, 0, "/auth/at",
@@ -829,7 +828,7 @@ oc_core_auth_at_x_get_handler(oc_request_t *request,
 
   /* check if the accept header is cbor-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
   PRINT("oc_core_auth_at_x_get_handler\n");
@@ -841,7 +840,7 @@ oc_core_auth_at_x_get_handler(oc_request_t *request,
     request->uri_path, request->uri_path_len, &value);
   // - delete the index.
   if (value_len <= 0) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     PRINT("  index (at) not found\n");
     return;
   }
@@ -850,7 +849,7 @@ oc_core_auth_at_x_get_handler(oc_request_t *request,
   int index = find_index_from_at_string(value, value_len);
   // - delete the index.
   if (index < 0) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     PRINT("  index in structure not found\n");
     return;
   }
@@ -951,7 +950,7 @@ oc_core_auth_at_x_post_handler(oc_request_t *request,
   int cmd = 0;
   /* check if the accept header is cbor-format */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     return;
   }
   PRINT("oc_core_auth_at_x_post_handler\n");
@@ -975,7 +974,7 @@ oc_core_auth_at_x_post_handler(oc_request_t *request,
     oc_send_cbor_response(request, OC_STATUS_CHANGED);
     return;
   }
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 static void
@@ -1001,7 +1000,7 @@ oc_core_auth_at_x_delete_handler(oc_request_t *request,
     request->uri_path, request->uri_path_len, &value);
   // - delete the index.
   if (value_len <= 0) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     PRINT("index (at) not found\n");
     return;
   }
@@ -1010,7 +1009,7 @@ oc_core_auth_at_x_delete_handler(oc_request_t *request,
   int index = find_index_from_at_string(value, value_len);
   // - delete the index.
   if (index < 0) {
-    oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
     PRINT("oc_core_auth_at_x_delete_handler: index in structure not found\n");
     return;
   }
@@ -1025,7 +1024,7 @@ oc_core_auth_at_x_delete_handler(oc_request_t *request,
 #endif
 
   PRINT("oc_core_auth_at_x_delete_handler - done\n");
-  oc_send_cbor_response_no_payload_size(request, OC_STATUS_DELETED);
+  oc_send_response_no_format(request, OC_STATUS_DELETED);
 }
 
 #ifdef OC_IOT_ROUTER
@@ -1084,7 +1083,7 @@ oc_core_knx_auth_get_handler(oc_request_t *request,
   if (matches > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   }
 }
 

--- a/api/oc_knx_swu.c
+++ b/api/oc_knx_swu.c
@@ -144,12 +144,11 @@ oc_knx_swu_protocol_put_handler(oc_request_t *request,
     PRINT("  oc_knx_swu_protocol_put_handler received : %d\n",
           (int)rep->value.integer);
 
-    // oc_send_cbor_response(request, OC_STATUS_OK);
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_CHANGED);
+    oc_send_response_no_format(request, OC_STATUS_CHANGED);
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_swu_protocol, knx_swu_maxdefer, 0,
@@ -214,12 +213,11 @@ oc_knx_swu_maxdefer_put_handler(oc_request_t *request,
     g_swu_max_defer = (int)rep->value.integer;
     oc_storage_write(KNX_STORAGE_SWU_MAX_DEFER, (uint8_t *)&g_swu_max_defer,
                      sizeof(g_swu_max_defer));
-    // oc_send_cbor_response(request, OC_STATUS_OK);
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_OK);
+    oc_send_response_no_format(request, OC_STATUS_OK);
     return;
   }
 
-  oc_send_json_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_swu_maxdefer, knx_swu_method, 0,
@@ -288,8 +286,7 @@ oc_knx_swu_method_put_handler(oc_request_t *request,
     g_swu_update_method = (int)rep->value.integer;
     oc_storage_write(KNX_STORAGE_SWU_METHOD, (uint8_t *)&g_swu_update_method,
                      sizeof(g_swu_update_method));
-    // oc_send_cbor_response(request, OC_STATUS_OK);
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_OK);
+    oc_send_response_no_format(request, OC_STATUS_OK);
     return;
   }
 
@@ -448,12 +445,12 @@ oc_knx_swu_update_put_handler(oc_request_t *request,
   if ((rep != NULL) && (rep->type == OC_REP_INT)) {
     PRINT("  oc_knx_swu_update_put_handler received : %d\n",
           (int)rep->value.integer);
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_OK);
+    oc_send_response_no_format(request, OC_STATUS_OK);
     // oc_send_cbor_response(request, OC_STATUS_OK);
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_swu_update, knx_swu_pkgv, 0,
@@ -565,7 +562,7 @@ oc_knx_swu_a_put_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   PRINT("block_size: %d\n", block_size);
   PRINT("block_offset: %d\n", block_offset);
   // if (block_size == 0) {
-  //  oc_send_response(request, OC_STATUS_BAD_REQUEST);
+  //  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   //  return;
   //}
   size_t device_index = request->resource->device;
@@ -609,7 +606,7 @@ oc_knx_swu_a_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_swu_pkgcmd, knx_swu_pkgbytes, 0,
@@ -707,12 +704,11 @@ oc_knx_swu_pkgqurl_put_handler(oc_request_t *request,
     PRINT("  oc_knx_swu_pkgqurl_put_handler received : %s\n",
           oc_string_checked(rep->value.string));
 
-    // oc_send_cbor_response(request, OC_STATUS_OK);
-    oc_send_cbor_response_no_payload_size(request, OC_STATUS_OK);
+    oc_send_response_no_format(request, OC_STATUS_OK);
     return;
   }
 
-  oc_send_cbor_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_swu_pkgqurl, knx_swu_pkgnames, 0,
@@ -806,7 +802,7 @@ oc_core_knx_swu_get_handler(oc_request_t *request,
   if (matches > 0) {
     oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
   } else {
-    oc_send_linkformat_response(request, OC_STATUS_INTERNAL_SERVER_ERROR, 0);
+    oc_send_response_no_format(request, OC_STATUS_INTERNAL_SERVER_ERROR);
   }
 }
 

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1319,7 +1319,7 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
     oc_rep_new(response_buffer.buffer, (int)response_buffer.buffer_size);
 
     if (!oc_knx_sec_check_acl(method, cur_resource, endpoint)) {
-      authorized = false;
+      method_impl = false;
     } else
 
 #ifdef OC_SECURITY

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1394,8 +1394,6 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
      */
     response_buffer.response_length = 0;
     response_buffer.code = oc_status_code(OC_STATUS_METHOD_NOT_ALLOWED);
-    // For EITT test 5.2.3.1b
-    response_buffer.content_format = APPLICATION_CBOR;
   } else if (!authorized) {
     OC_WRN("ocri: Subject not authorized");
     /* If the requestor (subject) does not have access granted via an

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1319,7 +1319,7 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
     oc_rep_new(response_buffer.buffer, (int)response_buffer.buffer_size);
 
     if (!oc_knx_sec_check_acl(method, cur_resource, endpoint)) {
-      method_impl = false;
+      authorized = false;
     } else
 
 #ifdef OC_SECURITY

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -115,13 +115,6 @@ oc_send_cbor_response(oc_request_t *request, oc_status_t response_code)
 }
 
 void
-oc_send_cbor_response_no_payload_size(oc_request_t *request,
-                                      oc_status_t response_code)
-{
-  oc_send_cbor_response_with_payload_size(request, response_code, 0);
-}
-
-void
 oc_send_cbor_response_with_payload_size(oc_request_t *request,
                                         oc_status_t response_code,
                                         size_t payload_size)
@@ -566,7 +559,11 @@ oc_send_separate_response_with_length(oc_separate_response_t *handle,
   response_buffer.buffer = handle->response_state->buffer;
   response_buffer.response_length = length;
   response_buffer.code = oc_status_code(response_code);
-  response_buffer.content_format = APPLICATION_CBOR;
+  if (length > 0) {
+    response_buffer.content_format = APPLICATION_CBOR;
+  } else {
+    response_buffer.content_format = CONTENT_NONE;
+  }
 
   coap_separate_t *cur = oc_list_head(handle->requests), *next = NULL;
   coap_packet_t response[1];

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -151,6 +151,15 @@ oc_send_linkformat_response(oc_request_t *request, oc_status_t response_code,
 }
 
 void
+oc_send_response_no_format(oc_request_t *request, oc_status_t response_code,
+                            size_t response_length)
+{
+  request->response->response_buffer->content_format = CONTENT_NONE;
+  request->response->response_buffer->response_length = response_length;
+  request->response->response_buffer->code = oc_status_code(response_code);
+}
+
+void
 oc_ignore_request(oc_request_t *request)
 {
   request->response->response_buffer->code = OC_IGNORE;

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -562,7 +562,7 @@ oc_send_separate_response_with_length(oc_separate_response_t *handle,
   if (length > 0) {
     response_buffer.content_format = APPLICATION_CBOR;
   } else {
-    response_buffer.content_format = APPLICATION_CBOR;
+    response_buffer.content_format = CONTENT_NONE;
   }
 
   coap_separate_t *cur = oc_list_head(handle->requests), *next = NULL;

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -562,7 +562,7 @@ oc_send_separate_response_with_length(oc_separate_response_t *handle,
   if (length > 0) {
     response_buffer.content_format = APPLICATION_CBOR;
   } else {
-    response_buffer.content_format = CONTENT_NONE;
+    response_buffer.content_format = APPLICATION_CBOR;
   }
 
   coap_separate_t *cur = oc_list_head(handle->requests), *next = NULL;

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -151,11 +151,10 @@ oc_send_linkformat_response(oc_request_t *request, oc_status_t response_code,
 }
 
 void
-oc_send_response_no_format(oc_request_t *request, oc_status_t response_code,
-                            size_t response_length)
+oc_send_response_no_format(oc_request_t *request, oc_status_t response_code)
 {
   request->response->response_buffer->content_format = CONTENT_NONE;
-  request->response->response_buffer->response_length = response_length;
+  request->response->response_buffer->response_length = 0;
   request->response->response_buffer->code = oc_status_code(response_code);
 }
 

--- a/apps/lsab_minimal_all.c
+++ b/apps/lsab_minimal_all.c
@@ -198,7 +198,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
   PRINT("-- Begin get_dpa_417_61: interface %d\n", interfaces);
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     return;
   }
 
@@ -251,7 +251,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_cbor_response(request, OC_STATUS_BAD_OPTION);
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -271,7 +271,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
   }
   PRINT("-- End get_dpa_417_61\n");
 }
@@ -316,7 +316,7 @@ put_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
     rep = rep->next;
   }
 
-  oc_send_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   PRINT("-- End put_dpa_417_61\n");
 }
 

--- a/apps/lsab_minimal_all.c
+++ b/apps/lsab_minimal_all.c
@@ -198,7 +198,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
   PRINT("-- Begin get_dpa_417_61: interface %d\n", interfaces);
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     return;
   }
 
@@ -251,7 +251,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -271,7 +271,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
   }
   PRINT("-- End get_dpa_417_61\n");
 }

--- a/apps/lssb_minimal_all.c
+++ b/apps/lssb_minimal_all.c
@@ -215,7 +215,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
   PRINT("-- Begin get_dpa_421_61: interface %d\n", interfaces);
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     return;
   }
 
@@ -268,7 +268,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -288,7 +288,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
   }
   PRINT("-- End get_dpa_421_61\n");
 }

--- a/apps/lssb_minimal_all.c
+++ b/apps/lssb_minimal_all.c
@@ -215,7 +215,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
   PRINT("-- Begin get_dpa_421_61: interface %d\n", interfaces);
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     return;
   }
 
@@ -268,7 +268,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_cbor_response(request, OC_STATUS_BAD_OPTION);
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -288,7 +288,7 @@ get_o_1_1(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
   }
   PRINT("-- End get_dpa_421_61\n");
 }

--- a/apps/testserver_all.c
+++ b/apps/testserver_all.c
@@ -235,7 +235,7 @@ get_dpa_352_51(oc_request_t *request, oc_interface_mask_t interfaces,
   PRINT("-- Begin get_dpa_352_51\n");
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     return;
   }
   // handle the query parameter m
@@ -288,7 +288,7 @@ get_dpa_352_51(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_cbor_response(request, OC_STATUS_BAD_OPTION);
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -308,7 +308,7 @@ get_dpa_352_51(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
   }
   PRINT("-- End get_dpa_352_51\n");
 }
@@ -338,7 +338,7 @@ get_dpa_352_51_1(oc_request_t *request, oc_interface_mask_t interfaces,
   PRINT("-- Begin get_dpa_352_51_1\n");
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     return;
   }
   // check the query parameter m with the various values
@@ -390,7 +390,7 @@ get_dpa_352_51_1(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_cbor_response(request, OC_STATUS_BAD_OPTION);
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -411,7 +411,7 @@ get_dpa_352_51_1(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
   }
   PRINT("-- End get_dpa_352_51_1\n");
 }
@@ -440,7 +440,7 @@ get_dpa_352_52(oc_request_t *request, oc_interface_mask_t interfaces,
   PRINT("-- Begin get_dpa_352_52\n");
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     return;
   }
   // check the query parameter m with the various values
@@ -492,7 +492,7 @@ get_dpa_352_52(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_cbor_response(request, OC_STATUS_BAD_OPTION);
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -512,7 +512,7 @@ get_dpa_352_52(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
   }
   PRINT("-- End get_dpa_352_52\n");
 }
@@ -542,7 +542,7 @@ get_dpa_353_52(oc_request_t *request, oc_interface_mask_t interfaces,
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
     PRINT(" accept %d", request->accept);
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     return;
   }
   // check the query parameter m with the various values
@@ -594,7 +594,7 @@ get_dpa_353_52(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_cbor_response(request, OC_STATUS_BAD_OPTION);
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -612,7 +612,7 @@ get_dpa_353_52(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_OPTION);
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
   }
   PRINT("-- End get_dpa_353_52\n");
 }
@@ -659,7 +659,7 @@ put_dpa_352_51(oc_request_t *request, oc_interface_mask_t interfaces,
   }
 
   PRINT("  Returning Error \n");
-  oc_send_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   PRINT("-- End put_dpa_352_51\n");
 }
 
@@ -707,7 +707,7 @@ put_dpa_352_51_1(oc_request_t *request, oc_interface_mask_t interfaces,
   }
 
   PRINT("  Returning Error \n");
-  oc_send_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   PRINT("-- End put_dpa_352_51_1\n");
 }
 
@@ -756,7 +756,7 @@ put_dpa_352_52(oc_request_t *request, oc_interface_mask_t interfaces,
   /* if the input is ok, then process the input document and assign the global
    * variables */
   PRINT("  Returning Error \n");
-  oc_send_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   PRINT("-- End put_dpa_352_52\n");
 }
 
@@ -798,7 +798,7 @@ put_dpa_353_52(oc_request_t *request, oc_interface_mask_t interfaces,
     }
     rep = rep->next;
   }
-  oc_send_response(request, OC_STATUS_BAD_REQUEST);
+  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
   PRINT("-- End put_dpa_353_52\n");
 }
 

--- a/apps/testserver_all.c
+++ b/apps/testserver_all.c
@@ -235,7 +235,7 @@ get_dpa_352_51(oc_request_t *request, oc_interface_mask_t interfaces,
   PRINT("-- Begin get_dpa_352_51\n");
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     return;
   }
   // handle the query parameter m
@@ -288,7 +288,7 @@ get_dpa_352_51(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -308,7 +308,7 @@ get_dpa_352_51(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
   }
   PRINT("-- End get_dpa_352_51\n");
 }
@@ -338,7 +338,7 @@ get_dpa_352_51_1(oc_request_t *request, oc_interface_mask_t interfaces,
   PRINT("-- Begin get_dpa_352_51_1\n");
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     return;
   }
   // check the query parameter m with the various values
@@ -390,7 +390,7 @@ get_dpa_352_51_1(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -411,7 +411,7 @@ get_dpa_352_51_1(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
   }
   PRINT("-- End get_dpa_352_51_1\n");
 }
@@ -440,7 +440,7 @@ get_dpa_352_52(oc_request_t *request, oc_interface_mask_t interfaces,
   PRINT("-- Begin get_dpa_352_52\n");
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     return;
   }
   // check the query parameter m with the various values
@@ -492,7 +492,7 @@ get_dpa_352_52(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -512,7 +512,7 @@ get_dpa_352_52(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
   }
   PRINT("-- End get_dpa_352_52\n");
 }
@@ -542,7 +542,7 @@ get_dpa_353_52(oc_request_t *request, oc_interface_mask_t interfaces,
   /* check if the accept header is CBOR */
   if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
     PRINT(" accept %d", request->accept);
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     return;
   }
   // check the query parameter m with the various values
@@ -594,7 +594,7 @@ get_dpa_353_52(oc_request_t *request, oc_interface_mask_t interfaces,
       oc_rep_end_root_object();
     } else {
       /* device is NULL */
-      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+      oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
     }
     oc_send_cbor_response(request, OC_STATUS_OK);
     return;
@@ -612,7 +612,7 @@ get_dpa_353_52(oc_request_t *request, oc_interface_mask_t interfaces,
   if (error_state == false) {
     oc_send_cbor_response(request, oc_status_code);
   } else {
-    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION));
+    oc_send_response_no_format(request, OC_STATUS_BAD_OPTION);
   }
   PRINT("-- End get_dpa_353_52\n");
 }

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1047,7 +1047,6 @@ void oc_send_linkformat_response(oc_request_t *request,
  *
  * @param request the request being responded to
  * @param response_code the request being responded to
- * @param response_length the framed response length
  */
 void oc_send_response_no_format(oc_request_t *request,
                                 oc_status_t response_code);

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1067,8 +1067,7 @@ void oc_send_linkformat_response(oc_request_t *request,
  * @param response_length the framed response length
  */
 void
-oc_send_response_no_format(oc_request_t *request, oc_status_t response_code,
-                            size_t response_length);
+oc_send_response_no_format(oc_request_t *request, oc_status_t response_code);
 
 /**
  * @brief retrieve the payload from the request, no processing

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1049,8 +1049,8 @@ void oc_send_linkformat_response(oc_request_t *request,
  * @param response_code the request being responded to
  * @param response_length the framed response length
  */
-void
-oc_send_response_no_format(oc_request_t *request, oc_status_t response_code);
+void oc_send_response_no_format(oc_request_t *request,
+                                oc_status_t response_code);
 
 /**
  * @brief retrieve the payload from the request, no processing

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -991,23 +991,6 @@ void oc_send_cbor_response(oc_request_t *request, oc_status_t response_code);
 
 /**
  * @brief Called after the response to a GET, PUT, POST or DELETE call has been
- * prepared completed. will respond with CBOR, no payload expected.
- *
- * The function oc_send_response is called at the end of a
- * oc_request_callback_t to inform the caller about the status of the requested
- * action.
- *
- * Note that OC_STATUS_BAD_REQUEST for multicast will not send a response (e.g.
- * threated as OC_IGNORE)
- *
- * @param request the request being responded to
- * @param response_code the status of the response
- */
-void oc_send_cbor_response_no_payload_size(oc_request_t *request,
-                                           oc_status_t response_code);
-
-/**
- * @brief Called after the response to a GET, PUT, POST or DELETE call has been
  * prepared completed. will respond with CBOR.
  *
  * The function oc_send_response is called at the end of a

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1057,6 +1057,20 @@ void oc_send_linkformat_response(oc_request_t *request,
                                  size_t response_length);
 
 /**
+ * @brief Called after the response to a GET, PUT, POST or DELETE call has been
+ * prepared completed. will respond without setting the content format.
+ *
+ * Example usecase: When the response has empty payload.
+ *
+ * @param request the request being responded to
+ * @param response_code the request being responded to
+ * @param response_length the framed response length
+ */
+void
+oc_send_response_no_format(oc_request_t *request, oc_status_t response_code,
+                            size_t response_length);
+
+/**
  * @brief retrieve the payload from the request, no processing
  *
  * @param request the request

--- a/messaging/coap/coap.c
+++ b/messaging/coap/coap.c
@@ -645,7 +645,7 @@ coap_oscore_parse_options(void *packet, uint8_t *data, uint32_t data_len,
       coap_pkt->content_format =
         (uint16_t)coap_parse_int_option(current_option, option_length);
       OC_DBG("  Content-Format [%u]", coap_pkt->content_format);
-      if (coap_pkt->content_format != APPLICATION_OSCORE &&
+      if (coap_pkt->payload_len > 0 && coap_pkt->content_format != APPLICATION_OSCORE &&
           coap_pkt->content_format != APPLICATION_CBOR &&
           coap_pkt->content_format != APPLICATION_LINK_FORMAT &&
           coap_pkt->content_format != APPLICATION_OCTET_STREAM &&

--- a/messaging/coap/coap.c
+++ b/messaging/coap/coap.c
@@ -645,7 +645,8 @@ coap_oscore_parse_options(void *packet, uint8_t *data, uint32_t data_len,
       coap_pkt->content_format =
         (uint16_t)coap_parse_int_option(current_option, option_length);
       OC_DBG("  Content-Format [%u]", coap_pkt->content_format);
-      if (coap_pkt->payload_len > 0 && coap_pkt->content_format != APPLICATION_OSCORE &&
+      if (coap_pkt->payload_len > 0 &&
+          coap_pkt->content_format != APPLICATION_OSCORE &&
           coap_pkt->content_format != APPLICATION_CBOR &&
           coap_pkt->content_format != APPLICATION_LINK_FORMAT &&
           coap_pkt->content_format != APPLICATION_OCTET_STREAM &&

--- a/tests/itc/ri/helper/RIHelper.cpp
+++ b/tests/itc/ri/helper/RIHelper.cpp
@@ -226,7 +226,7 @@ RIHelper::postLightCb(oc_request_t *request, oc_interface_mask_t interface,
       PRINT("value: %d\n", state);
       break;
     default:
-      oc_send_response(request, OC_STATUS_BAD_REQUEST);
+      oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
       return;
       break;
     }


### PR DESCRIPTION
Main changes:

1. Stop setting content format for responses with empty payload
2. Fix /p redirecting mechanism
3. In coap receiver: check payload length before checking content format
4. (According to recent spec changes) For multicast discoveries, only include ep in response payload