### PR TITLE
add api for number of free buffers

### DIFF
--- a/api/oc_buffer.c
+++ b/api/oc_buffer.c
@@ -291,3 +291,13 @@ oc_get_incoming_message_with_ptr(uint8_t *data)
   }
   return NULL;
 }
+
+int oc_buffer_num_free_incoming()
+{
+  return oc_memb_numfree(&oc_incoming_buffers);
+}
+
+int oc_buffer_num_free_outgoing()
+{
+  return oc_memb_numfree(&oc_outgoing_buffers);
+}

--- a/api/oc_buffer.c
+++ b/api/oc_buffer.c
@@ -292,12 +292,14 @@ oc_get_incoming_message_with_ptr(uint8_t *data)
   return NULL;
 }
 
-int oc_buffer_num_free_incoming()
+int
+oc_buffer_num_free_incoming()
 {
   return oc_memb_numfree(&oc_incoming_buffers);
 }
 
-int oc_buffer_num_free_outgoing()
+int
+oc_buffer_num_free_outgoing()
 {
   return oc_memb_numfree(&oc_outgoing_buffers);
 }

--- a/include/oc_buffer.h
+++ b/include/oc_buffer.h
@@ -91,6 +91,22 @@ void oc_recv_message(oc_message_t *message);
 void oc_send_message(oc_message_t *message);
 
 /**
+ * @brief Get the number of incoming buffers. If this reaches zero, the KNX-IoT
+ * stack will drop further received UDP messages
+ *
+ * @return int the number of buffers
+ */
+int oc_buffer_num_free_incoming();
+
+/**
+ * @brief Get the number of outgoing buffers. If this is zero and you attempt
+ * to send out a message, it will be silently dropped
+ *
+ * @return int the number of buffers
+ */
+int oc_buffer_num_free_outgoing();
+
+/**
  * @brief close all tls session for the specific device
  *
  * @param device the device index


### PR DESCRIPTION
Adds the `oc_buffer_num_free_incoming` and `oc_buffer_num_free_outgoing` functions which can be used to determine whether it is safe to send or receive a KNX-IoT packet.