### PR TITLE
check for null in send response functions

### DIFF
--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -805,8 +805,8 @@ oc_core_knx_k_post_handler(oc_request_t *request,
   memset(&response_buffer, 0, sizeof(oc_response_buffer_t));
   oc_response_t response_obj;
   memset(&response_obj, 0, sizeof(oc_response_t));
-  oc_ri_new_request_from_request(new_request, *request, response_buffer,
-                                 response_obj);
+  oc_ri_new_request_from_request(&new_request, request, &response_buffer,
+                                 &response_obj);
   new_request.request_payload = oc_s_mode_get_value(request);
   // new style
   new_request.uri_path = "k";

--- a/api/oc_knx_p.c
+++ b/api/oc_knx_p.c
@@ -194,8 +194,8 @@ oc_core_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
           memset(&response_buffer, 0, sizeof(oc_response_buffer_t));
           oc_response_t response_obj;
           memset(&response_obj, 0, sizeof(oc_response_t));
-          oc_ri_new_request_from_request(new_request, *request, response_buffer,
-                                         response_obj);
+          oc_ri_new_request_from_request(&new_request, request, &response_buffer,
+                                         &response_obj);
 
           new_request.request_payload = value;
           new_request.uri_path = oc_string(*myurl);

--- a/api/oc_knx_p.c
+++ b/api/oc_knx_p.c
@@ -194,8 +194,8 @@ oc_core_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
           memset(&response_buffer, 0, sizeof(oc_response_buffer_t));
           oc_response_t response_obj;
           memset(&response_obj, 0, sizeof(oc_response_t));
-          oc_ri_new_request_from_request(&new_request, request, &response_buffer,
-                                         &response_obj);
+          oc_ri_new_request_from_request(&new_request, request,
+                                         &response_buffer, &response_obj);
 
           new_request.request_payload = value;
           new_request.uri_path = oc_string(*myurl);

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -364,8 +364,8 @@ oc_ri_new_request_from_request(oc_request_t *new_request, oc_request_t *request,
   response_buffer->max_age = 0;
 
   response_obj->separate_response = NULL;
-  response_obj->response_buffer = &response_buffer;
-  new_request->response = &response_obj;
+  response_obj->response_buffer = response_buffer;
+  new_request->response = response_obj;
 
   return true;
 }

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -346,26 +346,26 @@ oc_print_interface(oc_interface_mask_t iface_mask)
 }
 
 bool
-oc_ri_new_request_from_request(oc_request_t new_request, oc_request_t request,
-                               oc_response_buffer_t response_buffer,
-                               oc_response_t response_obj)
+oc_ri_new_request_from_request(oc_request_t *new_request, oc_request_t *request,
+                               oc_response_buffer_t *response_buffer,
+                               oc_response_t *response_obj)
 {
-  memcpy(&new_request, &request, sizeof(request));
-  new_request.response = NULL;
+  memcpy(new_request, request, sizeof(request));
+  new_request->response = NULL;
 
   /* Postpone allocating response_state right after calling
    * oc_parse_rep()
    *  in order to reducing peak memory in OC_BLOCK_WISE &
    * OC_DYNAMIC_ALLOCATION
    */
-  response_buffer.code = 0;
-  response_buffer.response_length = 0;
-  response_buffer.content_format = 0;
-  response_buffer.max_age = 0;
+  response_buffer->code = 0;
+  response_buffer->response_length = 0;
+  response_buffer->content_format = 0;
+  response_buffer->max_age = 0;
 
-  response_obj.separate_response = NULL;
-  response_obj.response_buffer = &response_buffer;
-  new_request.response = &response_obj;
+  response_obj->separate_response = NULL;
+  response_obj->response_buffer = &response_buffer;
+  new_request->response = &response_obj;
 
   return true;
 }

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -129,26 +129,32 @@ oc_send_cbor_response_with_payload_size(oc_request_t *request,
 void
 oc_send_json_response(oc_request_t *request, oc_status_t response_code)
 {
-  request->response->response_buffer->content_format = APPLICATION_JSON;
-  request->response->response_buffer->response_length = response_length();
-  request->response->response_buffer->code = oc_status_code(response_code);
+  if (request && request->response && request->response->response_buffer) {
+    request->response->response_buffer->content_format = APPLICATION_JSON;
+    request->response->response_buffer->response_length = response_length();
+    request->response->response_buffer->code = oc_status_code(response_code);
+  }
 }
 
 void
 oc_send_linkformat_response(oc_request_t *request, oc_status_t response_code,
                             size_t response_length)
 {
-  request->response->response_buffer->content_format = APPLICATION_LINK_FORMAT;
-  request->response->response_buffer->response_length = response_length;
-  request->response->response_buffer->code = oc_status_code(response_code);
+  if (request && request->response && request->response->response_buffer) {
+    request->response->response_buffer->content_format = APPLICATION_LINK_FORMAT;
+    request->response->response_buffer->response_length = response_length;
+    request->response->response_buffer->code = oc_status_code(response_code);
+  }
 }
 
 void
 oc_send_response_no_format(oc_request_t *request, oc_status_t response_code)
 {
-  request->response->response_buffer->content_format = CONTENT_NONE;
-  request->response->response_buffer->response_length = 0;
-  request->response->response_buffer->code = oc_status_code(response_code);
+  if (request && request->response && request->response->response_buffer) {
+    request->response->response_buffer->content_format = CONTENT_NONE;
+    request->response->response_buffer->response_length = 0;
+    request->response->response_buffer->code = oc_status_code(response_code);
+  }
 }
 
 void

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -141,7 +141,8 @@ oc_send_linkformat_response(oc_request_t *request, oc_status_t response_code,
                             size_t response_length)
 {
   if (request && request->response && request->response->response_buffer) {
-    request->response->response_buffer->content_format = APPLICATION_LINK_FORMAT;
+    request->response->response_buffer->content_format =
+      APPLICATION_LINK_FORMAT;
     request->response->response_buffer->response_length = response_length;
     request->response->response_buffer->code = oc_status_code(response_code);
   }

--- a/include/oc_ri.h
+++ b/include/oc_ri.h
@@ -768,10 +768,10 @@ bool oc_ri_is_app_resource_valid(const oc_resource_t *resource);
  * @return true new request valid
  * @return false new request invalid
  */
-bool oc_ri_new_request_from_request(oc_request_t new_request,
-                                    oc_request_t request,
-                                    oc_response_buffer_t response_buffer,
-                                    oc_response_t response_obj);
+bool oc_ri_new_request_from_request(oc_request_t *new_request,
+                                    oc_request_t *request,
+                                    oc_response_buffer_t *response_buffer,
+                                    oc_response_t *response_obj);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The content format changes don't tolerate the response buffer being null, and the stack was hardfaulting when dereferencing the null pointer. The response buffer shouldn't be null for /k & /p redirects in the first place, but these checks are less risky than modifying the S-mode redirection right now.