### PR TITLE
Fix various device responses, allow GET on if.i resources

### DIFF
--- a/api/oc_knx_fb.c
+++ b/api/oc_knx_fb.c
@@ -457,6 +457,8 @@ oc_add_function_blocks_to_response(oc_request_t *request, size_t device_index,
       *response_length += length;
       length = oc_rep_add_line_to_buffer("\";");
       *response_length += length;
+      length = oc_rep_add_line_to_buffer("if=\":if.ll\";");
+      *response_length += length;
       /* content type application link format*/
       length = oc_rep_add_line_to_buffer("ct=40");
       *response_length += length;

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1874,6 +1874,8 @@ oc_if_method_allowed_according_to_mask(oc_interface_mask_t iface_mask,
 {
   if (iface_mask & OC_IF_I) {
     // logical input
+    if (method == OC_GET)
+      return true;
     if (method == OC_POST)
       return true;
     if (method == OC_PUT)

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -565,7 +565,7 @@ oc_core_auth_at_get_handler(oc_request_t *request,
         length = oc_rep_add_line_to_buffer(",\n");
         response_length += length;
       }
-      length = oc_rep_add_line_to_buffer("<auth/at/");
+      length = oc_rep_add_line_to_buffer("</auth/at/");
       response_length += length;
       length = oc_rep_add_line_to_buffer(oc_string(g_at_entries[i].id));
       response_length += length;


### PR DESCRIPTION
1. Functional blocks in e.g. discovery response now have interfaces if.ll, e.g. </f/00421_01>;rt=":fb.421";if=":if.ll";ct=40
2. Allow GET for if.i resources for metadata query parameter "m"