### PR TITLE
EITT fixes

### DIFF
--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -424,6 +424,8 @@ oc_wkcore_discovery_handler(oc_request_t *request,
       request, device_index, group_address, &response_length, matches);
     if (ret) {
       oc_send_linkformat_response(request, OC_STATUS_OK, response_length);
+    } else if (request->origin && (request->origin->flags & MULTICAST) == 0) {
+      oc_send_linkformat_response(request, OC_STATUS_OK, 0);
     } else {
       oc_ignore_request(request);
     }

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -262,7 +262,7 @@ oc_core_dev_model_get_handler(oc_request_t *request,
   oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
-OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_model, dev_ia, 0, "/dev/model",
+OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_model, dev_hostname, 0, "/dev/model",
                                      OC_IF_D, APPLICATION_CBOR, OC_DISCOVERABLE,
                                      oc_core_dev_model_get_handler, 0, 0, 0,
                                      "urn:knx:dpt.utf8", OC_SIZE_MANY(1),
@@ -278,125 +278,6 @@ oc_create_dev_model_resource(int resource_idx, size_t device)
                             "urn:knx:dpa.0.15");
 
   oc_core_bind_dpt_resource(resource_idx, device, "urn:knx:dpt.utf8");
-}
-
-// -----------------------------------------------------------------------------
-
-static void
-oc_core_dev_ia_get_handler(oc_request_t *request,
-                           oc_interface_mask_t iface_mask, void *data)
-{
-  (void)data;
-  (void)iface_mask;
-
-  /* check if the accept header is CBOR-format */
-  if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    OC_ERR("invalid request");
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-    return;
-  }
-
-  size_t device_index = request->resource->device;
-  oc_device_info_t *device = oc_core_get_device_info(device_index);
-  if (device != NULL) {
-    oc_rep_begin_root_object();
-    oc_rep_i_set_int(root, 12, device->ia);
-    oc_rep_i_set_int(root, 26, device->iid);
-    if (device->fid > 0) {
-      // only frame it when it is set...
-      oc_rep_i_set_int(root, 25, (int64_t)device->fid);
-    }
-    oc_rep_end_root_object();
-
-    oc_send_cbor_response(request, OC_STATUS_OK);
-    return;
-  }
-  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-}
-
-static void
-oc_core_dev_ia_put_handler(oc_request_t *request,
-                           oc_interface_mask_t iface_mask, void *data)
-{
-  (void)data;
-  (void)iface_mask;
-  bool error = false;
-  bool ia_set = false;
-  bool iid_set = false;
-  bool fid_set = false;
-
-  /* check if the accept header is CBOR-format */
-  if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-    return;
-  }
-
-  size_t device_index = request->resource->device;
-
-  oc_rep_t *rep = request->request_payload;
-  while (rep != NULL) {
-    if (rep->type == OC_REP_INT) {
-      if (rep->iname == 12) {
-        PRINT("  oc_core_dev_ia_put_handler received 12 (ia) : %d\n",
-              (int)rep->value.integer);
-        oc_core_set_device_ia(device_index, (uint32_t)rep->value.integer);
-        int temp = (int)rep->value.integer;
-        oc_storage_write(KNX_STORAGE_IA, (uint8_t *)&temp, sizeof(temp));
-        ia_set = true;
-      } else if (rep->iname == 25) {
-        PRINT("  oc_core_dev_ia_put_handler received 25 (fid): %d\n",
-              (int)rep->value.integer);
-        oc_core_set_device_fid(device_index, rep->value.integer);
-        int temp = (int)rep->value.integer;
-        oc_storage_write(KNX_STORAGE_FID, (uint8_t *)&temp, sizeof(temp));
-        fid_set = true;
-      } else if (rep->iname == 26) {
-        PRINT("  oc_core_dev_ia_put_handler received 26 (iid): %d\n",
-              (int)rep->value.integer);
-        oc_core_set_device_iid(device_index, (uint64_t)rep->value.integer);
-        uint64_t temp = (uint64_t)rep->value.integer;
-        oc_storage_write(KNX_STORAGE_IID, (uint8_t *)&temp, sizeof(temp));
-        iid_set = true;
-      }
-    }
-    rep = rep->next;
-  }
-  if (fid_set) {
-    OC_ERR("fid set in request: returning error!");
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-    return;
-  }
-
-  if (iid_set && ia_set) {
-    // do the run time installation
-    if (oc_is_device_in_runtime(device_index)) {
-      oc_register_group_multicasts();
-      oc_init_datapoints_at_initialization();
-    }
-
-    oc_send_response_no_format(request, OC_STATUS_CHANGED);
-  } else {
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-  }
-}
-
-OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_ia, dev_hostname, 0, "/dev/ia",
-                                     OC_IF_P, APPLICATION_CBOR, OC_DISCOVERABLE,
-                                     oc_core_dev_ia_get_handler,
-                                     oc_core_dev_ia_put_handler, 0, 0, NULL,
-                                     OC_SIZE_MANY(1),
-                                     "urn:knx:dpt.value2Ucount");
-
-void
-oc_create_dev_ia_resource(int resource_idx, size_t device)
-{
-  OC_DBG("oc_create_dev_ia_resource\n");
-  oc_core_populate_resource(
-    resource_idx, device, "/dev/ia", OC_IF_P, APPLICATION_CBOR, OC_DISCOVERABLE,
-    oc_core_dev_ia_get_handler, oc_core_dev_ia_put_handler, 0, 0, 1,
-    "urn:knx:dpt.value2Ucount");
-
-  // oc_core_bind_dpt_resource(resource_idx, device, "urn:knx:dpt.utf8");
 }
 
 // -----------------------------------------------------------------------------
@@ -1648,7 +1529,6 @@ oc_create_knx_device_resources(size_t device_index)
   oc_create_dev_fwv_resource(OC_DEV_FWV, device_index);
   oc_create_dev_hwt_resource(OC_DEV_HWT, device_index);
   oc_create_dev_model_resource(OC_DEV_MODEL, device_index);
-  oc_create_dev_ia_resource(OC_DEV_IA, device_index);
   oc_create_dev_hostname_resource(OC_DEV_HOSTNAME, device_index);
   oc_create_dev_iid_resource(OC_DEV_IID, device_index);
   oc_create_dev_pm_resource(OC_DEV_PM, device_index);

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -965,8 +965,7 @@ oc_core_dev_port_get_handler(oc_request_t *request,
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_port, dev_mport, 0, "/dev/port",
                                      OC_IF_P, APPLICATION_CBOR, OC_DISCOVERABLE,
-                                     oc_core_dev_port_get_handler,
-                                     0, 0, 0,
+                                     oc_core_dev_port_get_handler, 0, 0, 0,
                                      "urn:knx:dpt.value2Ucount",
                                      OC_SIZE_ZERO());
 
@@ -976,8 +975,7 @@ oc_create_dev_port_resource(int resource_idx, size_t device)
   OC_DBG("oc_create_dev_port_resource\n");
   oc_core_populate_resource(resource_idx, device, "/dev/port", OC_IF_P,
                             APPLICATION_CBOR, OC_DISCOVERABLE,
-                            oc_core_dev_port_get_handler,
-                            0, 0, 0, 0);
+                            oc_core_dev_port_get_handler, 0, 0, 0, 0);
 
   oc_core_bind_dpt_resource(resource_idx, device, "urn:knx:dpt.value2Ucount");
 }

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -1082,43 +1082,10 @@ oc_core_dev_port_get_handler(oc_request_t *request,
   oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
 }
 
-static void
-oc_core_dev_port_put_handler(oc_request_t *request,
-                             oc_interface_mask_t iface_mask, void *data)
-{
-  (void)data;
-  (void)iface_mask;
-
-  /* check if the accept header is CBOR-format */
-  if (oc_check_accept_header(request, APPLICATION_CBOR) == false) {
-    oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-    return;
-  }
-
-  size_t device_index = request->resource->device;
-  oc_device_info_t *device = oc_core_get_device_info(device_index);
-  oc_rep_t *rep = request->request_payload;
-  // debugging
-  if (rep != NULL) {
-    PRINT("  oc_core_dev_port_put_handler type: %d\n", rep->type);
-  }
-
-  if ((rep != NULL) && (rep->type == OC_REP_INT)) {
-    PRINT("  oc_core_dev_port_put_handler received : %d\n",
-          (int)rep->value.integer);
-    device->port = (uint32_t)rep->value.integer;
-    oc_send_response_no_format(request, OC_STATUS_CHANGED);
-    oc_storage_write(KNX_STORAGE_PORT, (uint8_t *)&(rep->value.integer), 1);
-    return;
-  }
-
-  oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-}
-
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(dev_port, dev_mport, 0, "/dev/port",
                                      OC_IF_P, APPLICATION_CBOR, OC_DISCOVERABLE,
                                      oc_core_dev_port_get_handler,
-                                     oc_core_dev_port_put_handler, 0, 0,
+                                     0, 0, 0,
                                      "urn:knx:dpt.value2Ucount",
                                      OC_SIZE_ZERO());
 
@@ -1129,7 +1096,7 @@ oc_create_dev_port_resource(int resource_idx, size_t device)
   oc_core_populate_resource(resource_idx, device, "/dev/port", OC_IF_P,
                             APPLICATION_CBOR, OC_DISCOVERABLE,
                             oc_core_dev_port_get_handler,
-                            oc_core_dev_port_put_handler, 0, 0, 0);
+                            0, 0, 0, 0);
 
   oc_core_bind_dpt_resource(resource_idx, device, "urn:knx:dpt.value2Ucount");
 }

--- a/include/oc_ri.h
+++ b/include/oc_ri.h
@@ -334,7 +334,6 @@ typedef enum {
   OC_DEV_HWT,   /**< The hardware type is a manufacture specific id for a device
                      type (MaC uses this id for compatibility checks) */
   OC_DEV_MODEL, /**< Device model */
-  OC_DEV_IA,    /**< Device individual address */
   OC_DEV_HOSTNAME,    /**< Device host name for DNS resolution. */
   OC_DEV_IID,         /**< KNX installation ID */
   OC_DEV_PM,          /**< Programming Mode */


### PR DESCRIPTION
1. Return empty response for unicast discovery with g.s query
2. Stop allowing PUT to /dev/port (was handling it but doing nothing in handler)
3. Remove old /dev/ia resource