### PR TITLE
EITT fixes

### DIFF
--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -900,6 +900,12 @@ oc_core_knx_k_post_handler(oc_request_t *request,
 
           my_resource->get_handler.cb(&new_request, iface_mask, NULL);
         }
+#ifdef OC_USE_MULTICAST_SCOPE_2
+        // oc_do_s_mode_with_scope_no_check(2, oc_string(myurl), "rp");
+        oc_do_s_mode_with_scope_no_check(2, oc_string(myurl), "a");
+#endif
+        // oc_do_s_mode_with_scope_no_check(5, oc_string(myurl), "rp");
+        oc_do_s_mode_with_scope_no_check(5, oc_string(myurl), "a");
       }
     }
     // get the next index in the table to get the url from.

--- a/api/oc_knx.c
+++ b/api/oc_knx.c
@@ -831,8 +831,8 @@ oc_core_knx_k_post_handler(oc_request_t *request,
         // calling the put handler, since datapoints are implementing GET/PUT
 
         if (my_resource->put_handler.cb) {
-          oc_ri_new_request_from_request(&new_request, request, &response_buffer,
-                                        &response_obj);
+          oc_ri_new_request_from_request(&new_request, request,
+                                         &response_buffer, &response_obj);
           new_request.request_payload = oc_s_mode_get_value(request);
           new_request.uri_path = "k";
           new_request.uri_path_len = 1;
@@ -859,8 +859,8 @@ oc_core_knx_k_post_handler(oc_request_t *request,
         // @receiver : cflags = u->overwrite object value
         // calling the put handler, since datapoints are implementing GET/PUT
         if (my_resource->put_handler.cb) {
-          oc_ri_new_request_from_request(&new_request, request, &response_buffer,
-                                        &response_obj);
+          oc_ri_new_request_from_request(&new_request, request,
+                                         &response_buffer, &response_obj);
           new_request.request_payload = oc_s_mode_get_value(request);
           new_request.uri_path = "k";
           new_request.uri_path_len = 1;
@@ -892,8 +892,8 @@ oc_core_knx_k_post_handler(oc_request_t *request,
         PRINT("   (case3) (RP-UPDATE) sending RP due to READ flag \n");
 
         if (my_resource->get_handler.cb) {
-          oc_ri_new_request_from_request(&new_request, request, &response_buffer,
-                                        &response_obj);
+          oc_ri_new_request_from_request(&new_request, request,
+                                         &response_buffer, &response_obj);
           new_request.uri_path = oc_string(myurl);
           new_request.uri_path_len = oc_string_len(myurl);
           new_request.accept = request->accept;

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -778,7 +778,7 @@ oc_core_dev_sa_get_handler(oc_request_t *request,
   oc_device_info_t *device = oc_core_get_device_info(device_index);
   if (device != NULL) {
     oc_rep_begin_root_object();
-    uint8_t sa = 255;
+    uint8_t sa = (uint8_t)((device->ia) >> 8);
     oc_rep_i_set_int(root, 1, sa);
     oc_rep_end_root_object();
 
@@ -827,7 +827,7 @@ oc_core_dev_da_get_handler(oc_request_t *request,
   if (device != NULL) {
     oc_rep_begin_root_object();
 
-    uint8_t da = 255;
+    uint8_t da = (uint8_t)(device->ia);
     oc_rep_i_set_int(root, 1, da);
     oc_rep_end_root_object();
     oc_send_cbor_response(request, OC_STATUS_OK);

--- a/api/oc_knx_dev.c
+++ b/api/oc_knx_dev.c
@@ -778,7 +778,7 @@ oc_core_dev_sa_get_handler(oc_request_t *request,
   oc_device_info_t *device = oc_core_get_device_info(device_index);
   if (device != NULL) {
     oc_rep_begin_root_object();
-    uint8_t sa = (uint8_t)((device->ia) >> 8);
+    uint8_t sa = 255;
     oc_rep_i_set_int(root, 1, sa);
     oc_rep_end_root_object();
 
@@ -827,7 +827,7 @@ oc_core_dev_da_get_handler(oc_request_t *request,
   if (device != NULL) {
     oc_rep_begin_root_object();
 
-    uint8_t da = (uint8_t)(device->ia);
+    uint8_t da = 255;
     oc_rep_i_set_int(root, 1, da);
     oc_rep_end_root_object();
     oc_send_cbor_response(request, OC_STATUS_OK);

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1675,7 +1675,7 @@ oc_oscore_set_auth_shared(char *client_senderid, int client_senderid_size,
   oc_new_string(&spake_entry.id, client_senderid, client_senderid_size);
   spake_entry.ga_len = 0;
   spake_entry.profile = OC_PROFILE_COAP_PASE;
-  spake_entry.scope = OC_IF_SEC | OC_IF_D | OC_IF_P;
+  spake_entry.scope = OC_IF_SEC;
   oc_new_byte_string(&spake_entry.osc_ms, (char *)shared_key, shared_key_size);
   // no context id
   oc_new_byte_string(&spake_entry.osc_rid, client_recipientid,

--- a/api/oc_knx_swu.c
+++ b/api/oc_knx_swu.c
@@ -116,7 +116,7 @@ oc_knx_swu_protocol_get_handler(oc_request_t *request,
   // Content-Format: "application/cbor"
   // Payload: [ 0 ]
   oc_rep_begin_root_object();
-  int64_t protocols[] = {0};
+  int64_t protocols[] = { 0 };
   oc_rep_i_set_int_array(root, 1, protocols, 1);
   oc_rep_end_root_object();
 
@@ -376,7 +376,6 @@ oc_knx_swu_result_get_handler(oc_request_t *request,
   oc_rep_i_set_int(root, 1, (int64_t)g_swu_result);
   oc_rep_end_root_object();
 
-
   oc_send_cbor_response(request, OC_STATUS_OK);
 }
 
@@ -498,7 +497,9 @@ oc_knx_swu_pkgv_get_handler(oc_request_t *request,
   }
   // Payload: [ 1, 2, 3 ]
   oc_rep_begin_root_object();
-  int64_t pkgv_arr[3] = {(int64_t)g_swu_package_version.major, (int64_t)g_swu_package_version.minor, (int64_t)g_swu_package_version.patch};
+  int64_t pkgv_arr[3] = { (int64_t)g_swu_package_version.major,
+                          (int64_t)g_swu_package_version.minor,
+                          (int64_t)g_swu_package_version.patch };
   oc_rep_i_set_int_array(root, 1, pkgv_arr, 3);
   oc_rep_end_root_object();
 

--- a/api/oc_knx_swu.c
+++ b/api/oc_knx_swu.c
@@ -33,7 +33,7 @@ static int g_swu_max_defer = 0;
 
 /* UPDATE METHOD*/
 #define KNX_STORAGE_SWU_METHOD "swu_knx_method"
-static int g_swu_update_method = 0;
+static int g_swu_update_method = 2;
 
 /* PACKAGE names*/
 /* note will be initialized with "" during creation of the resource*/
@@ -115,10 +115,10 @@ oc_knx_swu_protocol_get_handler(oc_request_t *request,
 
   // Content-Format: "application/cbor"
   // Payload: [ 0 ]
-  CborEncoder arrayEncoder;
-  cbor_encoder_create_array(&g_encoder, &arrayEncoder, 1);
-  cbor_encode_int(&arrayEncoder, (int64_t)0);
-  cbor_encoder_close_container(&g_encoder, &arrayEncoder);
+  oc_rep_begin_root_object();
+  int64_t protocols[] = {0};
+  oc_rep_i_set_int_array(root, 1, protocols, 1);
+  oc_rep_end_root_object();
 
   oc_send_cbor_response(request, OC_STATUS_OK);
   return;
@@ -187,9 +187,11 @@ oc_knx_swu_maxdefer_get_handler(oc_request_t *request,
   /*
    max defer in seconds
   */
-  cbor_encode_int(&g_encoder, (int64_t)g_swu_max_defer);
+  oc_rep_begin_root_object();
+  oc_rep_i_set_int(root, 1, (int64_t)g_swu_max_defer);
+  oc_rep_end_root_object();
 
-  oc_send_json_response(request, OC_STATUS_OK);
+  oc_send_cbor_response(request, OC_STATUS_OK);
 }
 
 static void
@@ -260,9 +262,11 @@ oc_knx_swu_method_get_handler(oc_request_t *request,
   2: Both (Initial value).
   */
   /* we are only going to support PUSH */
-  cbor_encode_int(&g_encoder, (int64_t)g_swu_update_method);
+  oc_rep_begin_root_object();
+  oc_rep_i_set_int(root, 1, (int64_t)g_swu_update_method);
+  oc_rep_end_root_object();
 
-  oc_send_json_response(request, OC_STATUS_OK);
+  oc_send_cbor_response(request, OC_STATUS_OK);
 }
 
 static void
@@ -291,7 +295,7 @@ oc_knx_swu_method_put_handler(oc_request_t *request,
     return;
   }
 
-  oc_send_json_response(request, OC_STATUS_OK);
+  oc_send_cbor_response(request, OC_STATUS_OK);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_swu_method, knx_lastupdate, 0,
@@ -327,9 +331,11 @@ oc_knx_swu_lastupdate_get_handler(oc_request_t *request,
   }
 
   // last update (time)
-  cbor_encode_text_stringz(&g_encoder, oc_string(g_swu_last_update));
+  oc_rep_begin_root_object();
+  oc_rep_i_set_text_string(root, 1, oc_string(g_swu_last_update));
+  oc_rep_end_root_object();
 
-  oc_send_json_response(request, OC_STATUS_OK);
+  oc_send_cbor_response(request, OC_STATUS_OK);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_lastupdate, knx_swu_result, 0,
@@ -366,9 +372,12 @@ oc_knx_swu_result_get_handler(oc_request_t *request,
   }
 
   // g_swu_state
-  cbor_encode_int(&g_encoder, (int64_t)g_swu_result);
+  oc_rep_begin_root_object();
+  oc_rep_i_set_int(root, 1, (int64_t)g_swu_result);
+  oc_rep_end_root_object();
 
-  oc_send_json_response(request, OC_STATUS_OK);
+
+  oc_send_cbor_response(request, OC_STATUS_OK);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_swu_result, knx_swu_state, 0,
@@ -404,9 +413,11 @@ oc_knx_swu_state_get_handler(oc_request_t *request,
   }
 
   // g_swu_state
-  cbor_encode_int(&g_encoder, (int64_t)g_swu_state);
+  oc_rep_begin_root_object();
+  oc_rep_i_set_int(root, 1, (int64_t)g_swu_state);
+  oc_rep_end_root_object();
 
-  oc_send_json_response(request, OC_STATUS_OK);
+  oc_send_cbor_response(request, OC_STATUS_OK);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_swu_state, knx_swu_update, 0,
@@ -486,14 +497,12 @@ oc_knx_swu_pkgv_get_handler(oc_request_t *request,
     return;
   }
   // Payload: [ 1, 2, 3 ]
-  CborEncoder arrayEncoder;
-  cbor_encoder_create_array(&g_encoder, &arrayEncoder, 3);
-  cbor_encode_int(&arrayEncoder, (int64_t)g_swu_package_version.major);
-  cbor_encode_int(&arrayEncoder, (int64_t)g_swu_package_version.minor);
-  cbor_encode_int(&arrayEncoder, (int64_t)g_swu_package_version.patch);
-  cbor_encoder_close_container(&g_encoder, &arrayEncoder);
+  oc_rep_begin_root_object();
+  int64_t pkgv_arr[3] = {(int64_t)g_swu_package_version.major, (int64_t)g_swu_package_version.minor, (int64_t)g_swu_package_version.patch};
+  oc_rep_i_set_int_array(root, 1, pkgv_arr, 3);
+  oc_rep_end_root_object();
 
-  oc_send_json_response(request, OC_STATUS_OK);
+  oc_send_cbor_response(request, OC_STATUS_OK);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_swu_pkgv, knx_swu_pkgcmd, 0,
@@ -576,7 +585,7 @@ oc_knx_swu_a_put_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
     my_cb->cb(device_index, &s_delayed_response_swu, binary_size, block_offset,
               (uint8_t *)payload, len, my_cb->data);
   } else {
-    oc_send_json_response(request, OC_STATUS_OK);
+    oc_send_cbor_response(request, OC_STATUS_OK);
   }
 
   PRINT("  oc_knx_swu_a_put_handler : End\n");
@@ -645,9 +654,11 @@ oc_knx_swu_bytes_get_handler(oc_request_t *request,
   }
 
   // g_swu_package_bytes
-  cbor_encode_int(&g_encoder, (int64_t)g_swu_package_bytes);
+  oc_rep_begin_root_object();
+  oc_rep_i_set_int(root, 1, (int64_t)g_swu_package_bytes);
+  oc_rep_end_root_object();
 
-  oc_send_json_response(request, OC_STATUS_OK);
+  oc_send_cbor_response(request, OC_STATUS_OK);
 }
 
 OC_CORE_CREATE_CONST_RESOURCE_LINKED(knx_swu_pkgbytes, knx_swu_pkgqurl, 0,
@@ -681,9 +692,11 @@ oc_knx_swu_pkgqurl_get_handler(oc_request_t *request,
       oc_status_code(OC_STATUS_BAD_REQUEST);
     return;
   }
-  cbor_encode_text_stringz(&g_encoder, oc_string(g_swu_qurl));
+  oc_rep_begin_root_object();
+  oc_rep_i_set_text_string(root, 1, oc_string(g_swu_qurl));
+  oc_rep_end_root_object();
 
-  oc_send_json_response(request, OC_STATUS_OK);
+  oc_send_cbor_response(request, OC_STATUS_OK);
 }
 
 static void
@@ -745,10 +758,9 @@ oc_knx_swu_pkgname_get_handler(oc_request_t *request,
     return;
   }
 
-  CborEncoder arrayEncoder;
-  cbor_encoder_create_array(&g_encoder, &arrayEncoder, 1);
-  cbor_encode_text_stringz(&arrayEncoder, oc_string(g_swu_package_name));
-  cbor_encoder_close_container(&g_encoder, &arrayEncoder);
+  oc_rep_begin_root_object();
+  oc_rep_i_set_text_string(root, 1, oc_string(g_swu_package_name));
+  oc_rep_end_root_object();
 
   oc_send_cbor_response(request, OC_STATUS_OK);
 }
@@ -892,7 +904,7 @@ oc_create_knx_swu_resources(size_t device_index)
     oc_create_knx_swu_resource(OC_KNX_SWU, device_index);
   }
   oc_swu_set_package_name("");
-  oc_swu_set_last_update("");
+  oc_swu_set_last_update("1970-01-01T00:00:00.00Z");
   oc_swu_set_package_version(0, 0, 0);
 }
 


### PR DESCRIPTION
~~1. Set default sna & da to 255, according to Spec Table 16~~
2. Set scope for temporary keys to if.sec only, according to Spec Table 53
3. s-mode "read" has in fact been broken for a long time... Upon receiving the original request to /k, the handler redirects the request by sending out a multicast s-mode request which is then handled by get_generic(), but no response will be returned because it's a multicast... Fixed by finding the resource object from within the stack and invoke its GET handler directly.
4. /swu/* resources are sending json responses for GET requests, when they should be cbor