### PR TITLE
implement ip address tracking in MID deduplication

### DIFF
--- a/messaging/coap/engine.h
+++ b/messaging/coap/engine.h
@@ -62,7 +62,7 @@ OC_PROCESS_NAME(coap_engine);
 void coap_init_engine(void);
 /*---------------------------------------------------------------------------*/
 int coap_receive(oc_message_t *message);
-bool oc_coap_check_if_duplicate(uint16_t mid, uint8_t device);
+bool oc_coap_check_if_duplicate(uint16_t mid, uint8_t device, uint16_t port, uint8_t address[16]);
 
 #ifdef __cplusplus
 }

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -159,7 +159,7 @@ oc_oscore_recv_message(oc_message_t *message)
     if (oscore_pkt->transport_type == COAP_TRANSPORT_UDP &&
         oscore_pkt->code <= OC_FETCH) {
       if (oc_coap_check_if_duplicate(oscore_pkt->mid,
-                                     message->endpoint.device)) {
+                                     message->endpoint.device, message->endpoint.addr.ipv6.port, message->endpoint.addr.ipv6.address)) {
         OC_DBG("dropping duplicate request");
         goto oscore_recv_error;
       }


### PR DESCRIPTION
Section 4.5 of the CoAP RFC states that "A recipient might receive the same Confirmable message (**as indicated by the Message ID and source endpoint**). So far, we've only been deduplicating messages based on the Message ID. This has been working well enough so far, but I've ran into trouble when running a KNX device directly on the border router. Here, the KNX device has multiple IP addresses, some of which are not routeable on all interfaces (e.g. the global Internet IPv6 address given to the router can only be routed to on the WAN interface, not the LAN).

This pull request adds IPv6 address & port tracking to the request deduplication code. The main consequence is that devices now respond to discovery requests several times, once for every IPv6 address. Overall this makes discovery more likely to succeed at the cost of somewhat increased traffic.

However, as far as I can tell ETS doesn't do very much with the extra discovery responses. Instead, it chooses to use the IP address of the first received CoAP response.

I'll open this as a draft so far, as it needs further testing. I think we should make sure this doesn't break programming with ETS using virtual & embedded devices before it can be merged.