### PR TITLE
Fix for non-confirmable responses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(OC_LOG_TO_FILE_ENABLED OFF CACHE BOOL "redirect debug messages to file")
 set(CLANG_TIDY_ENABLED OFF CACHE BOOL "Enable clang-tidy analysis during compilation.")
 set(OC_USE_STORAGE ON CACHE BOOL "Persistent storage of data.")
 set(OC_USE_MULTICAST_SCOPE_2 ON CACHE BOOL "devices send also group multicast events with scope2.")
-set(OC_REPLAY_PROTECTION_ENABLED OFF CACHE BOOL "Enable replay protection using the Echo option")
+set(OC_REPLAY_PROTECTION_ENABLED ON CACHE BOOL "Enable replay protection using the Echo option")
 
 set(KNX_BUILTIN_MBEDTLS ON CACHE BOOL "Use built-in mbedTLS, as opposed to external lib from different project")
 set(KNX_BUILTIN_TINYCBOR ON CACHE BOOL "Use built-in TinyCBOR, as opposed to external lib from different project")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(OC_LOG_TO_FILE_ENABLED OFF CACHE BOOL "redirect debug messages to file")
 set(CLANG_TIDY_ENABLED OFF CACHE BOOL "Enable clang-tidy analysis during compilation.")
 set(OC_USE_STORAGE ON CACHE BOOL "Persistent storage of data.")
 set(OC_USE_MULTICAST_SCOPE_2 ON CACHE BOOL "devices send also group multicast events with scope2.")
-set(OC_REPLAY_PROTECTION_ENABLED ON CACHE BOOL "Enable replay protection using the Echo option")
+set(OC_REPLAY_PROTECTION_ENABLED OFF CACHE BOOL "Enable replay protection using the Echo option")
 
 set(KNX_BUILTIN_MBEDTLS ON CACHE BOOL "Use built-in mbedTLS, as opposed to external lib from different project")
 set(KNX_BUILTIN_TINYCBOR ON CACHE BOOL "Use built-in TinyCBOR, as opposed to external lib from different project")

--- a/api/oc_knx_client.c
+++ b/api/oc_knx_client.c
@@ -665,7 +665,7 @@ oc_do_s_mode_read(int64_t group_address)
         (uint32_t)group_address, sia_value, iid);
 
   // find the grpid that belongs to the group address
-  grpid = oc_find_grpid_in_publisher_table(group_address);
+  grpid = oc_find_grpid_in_recipient_table(group_address);
   if (grpid > 0) {
 #ifdef OC_USE_MULTICAST_SCOPE_2
     oc_issue_s_mode(2, sia_value, grpid, group_address, iid, "r", 0, 0);

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -1030,7 +1030,7 @@ oc_oscore_send_message(oc_message_t *msg)
     }
 
     bool is_request =
-      coap_pkt->type == COAP_TYPE_CON || coap_pkt->type == COAP_TYPE_NON;
+      coap_pkt->code >= OC_GET && coap_pkt->code <= OC_FETCH;
     bool is_empty_ack = coap_pkt->type == COAP_TYPE_ACK && inner_code == 0;
     bool is_separate_response = coap_pkt->type == COAP_TYPE_CON;
     /* Set the OSCORE option */

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -1029,8 +1029,7 @@ oc_oscore_send_message(oc_message_t *msg)
       coap_set_header_max_age(coap_pkt, 0);
     }
 
-    bool is_request =
-      coap_pkt->code >= OC_GET && coap_pkt->code <= OC_FETCH;
+    bool is_request = coap_pkt->code >= OC_GET && coap_pkt->code <= OC_FETCH;
     bool is_empty_ack = coap_pkt->type == COAP_TYPE_ACK && inner_code == 0;
     bool is_separate_response = coap_pkt->type == COAP_TYPE_CON;
     /* Set the OSCORE option */


### PR DESCRIPTION
Previously all non-confirmable messages sent out by the device are considered requests, but they can be responses. This, combined with enabling the replay protection, caused ETS download to fail.

e.g. When ETS sends a NON request using a new unsynchronised access token, the device should send a non-confirmable RESPONSE with 4.01 + echo; But before the fix, it's sending a non-confirmable REQUEST with 4.01 + echo, which ETS cannot handle

Also a fix so that IPV6 multicast destination addresses are created using the recipient GRPID instead of publisher