### PR TITLE
do not send multicast message using thread-only source addresses

### DIFF
--- a/port/linux/ipadapter.c
+++ b/port/linux/ipadapter.c
@@ -1118,8 +1118,9 @@ oc_send_discovery_request(oc_message_t *message)
       struct sockaddr_in6 *addr = (struct sockaddr_in6 *)iface->ifa_addr;
       // check for Thread mesh local prefix
       memcpy(&message->endpoint.addr_local.ipv6.address, &addr->sin6_addr, 16);
-      uint8_t* epaddr = message->endpoint.addr_local.ipv6.address;
-      uint8_t thread_prefix[8] = {0xfd, 0xde, 0xad, 0x00, 0xbe, 0xef, 0x00, 0x00};
+      uint8_t *epaddr = message->endpoint.addr_local.ipv6.address;
+      uint8_t thread_prefix[8] = { 0xfd, 0xde, 0xad, 0x00,
+                                   0xbe, 0xef, 0x00, 0x00 };
       bool is_thread_mesh = memcmp(epaddr, thread_prefix, 8) == 0;
       if (is_thread_mesh)
         continue;

--- a/port/linux/ipadapter.c
+++ b/port/linux/ipadapter.c
@@ -1117,14 +1117,12 @@ oc_send_discovery_request(oc_message_t *message)
         iface->ifa_addr->sa_family == AF_INET6) {
       struct sockaddr_in6 *addr = (struct sockaddr_in6 *)iface->ifa_addr;
       // check for Thread mesh local prefix
-      bool is_thread_mesh = 
-        addr->sin6_addr.__in6_u.__u6_addr16[0] == 0xfdde
-        && addr->sin6_addr.__in6_u.__u6_addr16[1] == 0xad00
-        && addr->sin6_addr.__in6_u.__u6_addr16[2] == 0xbeef
-        && addr->sin6_addr.__in6_u.__u6_addr16[3] == 0x0000;
+      memcpy(&message->endpoint.addr_local.ipv6.address, &addr->sin6_addr, 16);
+      uint8_t* epaddr = message->endpoint.addr_local.ipv6.address;
+      uint8_t thread_prefix[8] = {0xfd, 0xde, 0xad, 0x00, 0xbe, 0xef, 0x00, 0x00};
+      bool is_thread_mesh = memcmp(epaddr, thread_prefix, 8) == 0;
       if (is_thread_mesh)
         continue;
-      memcpy(&message->endpoint.addr_local.ipv6.address, &addr->sin6_addr, 16);
       unsigned int mif = if_nametoindex(iface->ifa_name);
       if (setsockopt(dev->server_sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, &mif,
                      sizeof(mif)) == -1) {

--- a/port/linux/ipadapter.c
+++ b/port/linux/ipadapter.c
@@ -1116,6 +1116,14 @@ oc_send_discovery_request(oc_message_t *message)
     if ((message->endpoint.flags & IPV6) && iface->ifa_addr &&
         iface->ifa_addr->sa_family == AF_INET6) {
       struct sockaddr_in6 *addr = (struct sockaddr_in6 *)iface->ifa_addr;
+      // check for Thread mesh local prefix
+      bool is_thread_mesh = 
+        addr->sin6_addr.__in6_u.__u6_addr16[0] == 0xfdde
+        && addr->sin6_addr.__in6_u.__u6_addr16[1] == 0xad00
+        && addr->sin6_addr.__in6_u.__u6_addr16[2] == 0xbeef
+        && addr->sin6_addr.__in6_u.__u6_addr16[3] == 0x0000;
+      if (is_thread_mesh)
+        continue;
       memcpy(&message->endpoint.addr_local.ipv6.address, &addr->sin6_addr, 16);
       unsigned int mif = if_nametoindex(iface->ifa_name);
       if (setsockopt(dev->server_sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, &mif,


### PR DESCRIPTION
These messages can only receive answers from within the Thread network, whereas an Unique Local Address, which is also sent, can be responded to from within and from outside of the Thread network.

Consequently, this PR drastically cuts down the number of IPv6 multicasts issued for every s-mode message, as there are 4 or so Thread-only addresses.