### PR TITLE
Salt implementation

### DIFF
--- a/api/oc_knx_client.c
+++ b/api/oc_knx_client.c
@@ -397,9 +397,21 @@ int
 oc_knx_client_do_broker_request(const char *resource_url, uint64_t iid,
                                 uint32_t ia, char *destination, char *rp)
 {
-  char query[20];
+  char query[50] = "";
 
-  snprintf(query, 20, "ep=knx://ia.%llu.%lu", iid, ia);
+  char prefix[20];
+  snprintf(prefix, 13, "ep=knx://ia.");
+  strcat(query, prefix);
+
+  char iid_hex[20];
+  oc_conv_uint64_to_hex_string(iid_hex, iid);
+  strcat(query, iid_hex);
+
+  char ia_str[11];
+  snprintf(ia_str, 11, ".%x", ia);
+  strcat(query, ia_str);
+
+  PRINT("oc_knx_client_do_broker_request: query=%s\n", query);
 
   // not sure if we should use a malloc here, what would happen if there are no
   // devices found? because that causes a memory leak

--- a/api/oc_knx_fp.c
+++ b/api/oc_knx_fp.c
@@ -133,11 +133,7 @@ find_empty_slot_in_group_object_table(int id)
     /* should be a positive number */
     return index;
   }
-  index = oc_core_find_index_in_group_object_table_from_id(id);
-  if (index > -1) {
-    /* overwrite existing index */
-    return index;
-  }
+
   /* empty slot */
   for (int i = 0; i < GOT_MAX_ENTRIES; i++) {
     if (g_got[i].id == -1) {
@@ -562,12 +558,12 @@ oc_core_fp_g_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
       } else {
         // no index, so we will create one
         return_status = OC_STATUS_CREATED;
-      }
-      index = find_empty_slot_in_group_object_table(id);
-      if (index == -1) {
-        OC_ERR("  ERROR index %d", index);
-        oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-        return;
+        index = find_empty_slot_in_group_object_table(id);
+        if (index == -1) {
+          OC_ERR("  ERROR index %d", index);
+          oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
+          return;
+        }
       }
 
       bool id_only = true;
@@ -974,13 +970,13 @@ oc_core_fp_p_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
       } else {
         // no index, so we will create one
         return_status = OC_STATUS_CREATED;
-      }
-      index = find_empty_slot_in_rp_table(id, g_gpt,
-                                          oc_core_get_publisher_table_size());
-      if (index == -1) {
-        PRINT("  ERROR index %d\n", index);
-        oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-        return;
+        index = find_empty_slot_in_rp_table(id, g_gpt,
+                                            oc_core_get_publisher_table_size());
+        if (index == -1) {
+          PRINT("  ERROR index %d\n", index);
+          oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
+          return;
+        }
       }
       g_gpt[index].id = id;
 
@@ -1408,13 +1404,16 @@ oc_core_fp_r_post_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
       } else {
         // no index, so we will create one
         return_status = OC_STATUS_CREATED;
-      }
-      index = find_empty_slot_in_rp_table(id, g_grt,
-                                          oc_core_get_recipient_table_size());
-      if (index == -1) {
-        OC_ERR("  ERROR index %d", index);
-        oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
-        return;
+        index = find_empty_slot_in_rp_table(id, g_grt,
+                                            oc_core_get_recipient_table_size());
+        if (index == -1) {
+          OC_ERR("  ERROR index %d", index);
+          oc_send_response_no_format(request, OC_STATUS_BAD_REQUEST);
+          return;
+        }
+        // Initialise non & mt for new entry
+        g_grt[index].non = false;
+        g_grt[index].mt = 4;
       }
       g_grt[index].id = id;
 
@@ -2316,11 +2315,6 @@ find_empty_slot_in_rp_table(int id, oc_group_rp_table_t *rp_table, int max_size)
   int index = -1;
   if (id < 0) {
     // should be a positive number
-    return index;
-  }
-  index = oc_core_find_index_in_rp_table_from_id(id, rp_table, max_size);
-  if (index > -1) {
-    // overwrite existing index
     return index;
   }
 

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -733,6 +733,13 @@ oc_core_auth_at_post_handler(oc_request_t *request,
           //                oc_string(object->value.string),
           //                oc_string_len(object->value.string));
           //}
+          if (object->iname == 5) {
+            // salt
+            oc_free_string(&(g_at_entries[index].osc_salt));
+            oc_new_string(&g_at_entries[index].osc_salt,
+                          oc_string(object->value.string),
+                          oc_string_len(object->value.string));
+          }
         } else if (object->type == OC_REP_INT) {
           id_only = false;
           if (object->iname == 38) {

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -814,8 +814,8 @@ oc_core_auth_at_post_handler(oc_request_t *request,
                     // cnf::osc::salt
                     oc_free_string(&(g_at_entries[index].osc_salt));
                     oc_new_byte_string(&g_at_entries[index].osc_salt,
-                                  oc_string(oscobject->value.string),
-                                  oc_string_len(oscobject->value.string));
+                                       oc_string(oscobject->value.string),
+                                       oc_string_len(oscobject->value.string));
                     other_updated = true;
                   }
                 } /* type */

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -733,13 +733,6 @@ oc_core_auth_at_post_handler(oc_request_t *request,
           //                oc_string(object->value.string),
           //                oc_string_len(object->value.string));
           //}
-          if (object->iname == 5) {
-            // salt
-            oc_free_string(&(g_at_entries[index].osc_salt));
-            oc_new_string(&g_at_entries[index].osc_salt,
-                          oc_string(object->value.string),
-                          oc_string_len(object->value.string));
-          }
         } else if (object->type == OC_REP_INT) {
           id_only = false;
           if (object->iname == 38) {
@@ -815,6 +808,14 @@ oc_core_auth_at_post_handler(oc_request_t *request,
                                        oc_string(oscobject->value.string),
                                        oc_string_len(oscobject->value.string));
                     other_updated = true;
+                  }
+                  if (oscobject->iname == 0 && subobject_nr == 8 &&
+                      oscobject_nr == 4) {
+                    // cnf::osc::salt
+                    oc_free_string(&(g_at_entries[index].osc_salt));
+                    oc_new_byte_string(&g_at_entries[index].osc_salt,
+                                  oc_string(object->value.string),
+                                  oc_string_len(object->value.string));
                   }
                 } /* type */
 

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -809,13 +809,14 @@ oc_core_auth_at_post_handler(oc_request_t *request,
                                        oc_string_len(oscobject->value.string));
                     other_updated = true;
                   }
-                  if (oscobject->iname == 0 && subobject_nr == 8 &&
+                  if (oscobject->iname == 5 && subobject_nr == 8 &&
                       oscobject_nr == 4) {
                     // cnf::osc::salt
                     oc_free_string(&(g_at_entries[index].osc_salt));
                     oc_new_byte_string(&g_at_entries[index].osc_salt,
-                                  oc_string(object->value.string),
-                                  oc_string_len(object->value.string));
+                                  oc_string(oscobject->value.string),
+                                  oc_string_len(oscobject->value.string));
+                    other_updated = true;
                   }
                 } /* type */
 
@@ -1264,6 +1265,11 @@ oc_print_auth_at_entry(size_t device_index, int index)
                 (int)oc_byte_string_len(g_at_entries[index].osc_ms));
           oc_string_println_hex(g_at_entries[index].osc_ms);
         }
+        if (oc_string_len(g_at_entries[index].osc_salt) > 0) {
+          PRINT("    osc:salt    (h) : (%d) ",
+                (int)oc_byte_string_len(g_at_entries[index].osc_salt));
+          oc_string_println_hex(g_at_entries[index].osc_salt);
+        }
         if (oc_string_len(g_at_entries[index].osc_contextid) > 0) {
           PRINT("    osc:ctx_id (h): (%d) ",
                 (int)oc_byte_string_len(g_at_entries[index].osc_contextid));
@@ -1323,6 +1329,8 @@ oc_at_delete_entry(size_t device_index, int index)
   // oscore object
   oc_free_string(&g_at_entries[index].osc_ms);
   oc_new_byte_string(&g_at_entries[index].osc_ms, "", 0);
+  oc_free_string(&g_at_entries[index].osc_salt);
+  oc_new_byte_string(&g_at_entries[index].osc_salt, "", 0);
   oc_free_string(&g_at_entries[index].osc_contextid);
   oc_new_byte_string(&g_at_entries[index].osc_contextid, "", 0);
   oc_free_string(&g_at_entries[index].osc_rid);
@@ -1840,6 +1848,8 @@ oc_init_oscore_from_storage(size_t device_index, bool from_storage)
           oc_byte_string_len(g_at_entries[i].osc_rid), ssn, "desc",
           oc_string(g_at_entries[i].osc_ms),
           oc_byte_string_len(g_at_entries[i].osc_ms),
+          oc_string(g_at_entries[i].osc_salt),
+          oc_byte_string_len(g_at_entries[i].osc_salt),
           oc_string(g_at_entries[i].osc_contextid),
           oc_byte_string_len(g_at_entries[i].osc_contextid), i, from_storage);
         if (ctx == NULL) {

--- a/api/oc_knx_sec.c
+++ b/api/oc_knx_sec.c
@@ -1335,6 +1335,14 @@ oc_at_delete_entry(size_t device_index, int index)
   oc_free_string(&g_at_entries[index].kid);
   oc_new_string(&g_at_entries[index].kid, "", 0);
 
+  if (g_at_entries[index].ga_len > 0) {
+    uint64_t *cur_arr = g_at_entries[index].ga;
+    if (cur_arr) {
+      free(cur_arr);
+    }
+    g_at_entries[index].ga_len = 0;
+  }
+
   char filename[20];
   snprintf(filename, 20, "%s_%d", AT_STORE, index);
   oc_storage_erase(filename);
@@ -1378,7 +1386,6 @@ oc_at_dump_entry(size_t device_index, int entry)
                            oc_byte_string_len(g_at_entries[entry].osc_id));
   oc_rep_i_set_text_string(root, 82, oc_string(g_at_entries[entry].sub));
   oc_rep_i_set_text_string(root, 81, oc_string(g_at_entries[entry].kid));
-
   oc_rep_i_set_int_array(root, 777, g_at_entries[entry].ga,
                          g_at_entries[entry].ga_len);
 

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -346,7 +346,8 @@ oc_oscore_context_t *
 oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
                       const char *recipientid, int recipientid_size,
                       uint64_t ssn, const char *desc, const char *mastersecret,
-                      int mastersecret_size, const char *osc_ctx,
+                      int mastersecret_size, const char *salt,
+                      int salt_size, const char *osc_ctx,
                       int osc_ctx_size, int auth_at_index, bool from_storage)
 {
   PRINT("-----oc_oscore_add_context--SID:");
@@ -397,6 +398,8 @@ oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
   oc_char_println_hex(osc_ctx, osc_ctx_size);
   PRINT("  ms size   : %d ", mastersecret_size);
   oc_char_println_hex(mastersecret, mastersecret_size);
+  PRINT("  salt size : %d ", salt_size);
+  oc_char_println_hex(salt, salt_size);
 
   /* To prevent SSN reuse, bump to higher value that could've been previously
    * used, accounting for any failed writes to nonvolatile storage.
@@ -455,7 +458,7 @@ oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
   OC_DBG_OSCORE("### \t\tderiving Sender key ###");
   if (oc_oscore_context_derive_param(
         ctx->sendid, ctx->sendid_len, ctx->idctx, ctx->idctx_len, "Key",
-        (uint8_t *)mastersecret, mastersecret_size, NULL, 0, ctx->sendkey,
+        (uint8_t *)mastersecret, mastersecret_size, salt, salt_size, ctx->sendkey,
         OSCORE_KEY_LEN) < 0) {
     OC_ERR("*** error deriving Sender key ###");
     goto add_oscore_context_error;
@@ -469,7 +472,7 @@ oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
   OC_DBG_OSCORE("### \t\tderiving Recipient key ###");
   if (oc_oscore_context_derive_param(
         ctx->recvid, ctx->recvid_len, ctx->idctx, ctx->idctx_len, "Key",
-        (uint8_t *)mastersecret, mastersecret_size, NULL, 0, ctx->recvkey,
+        (uint8_t *)mastersecret, mastersecret_size, salt, salt_size, ctx->recvkey,
         OSCORE_KEY_LEN) < 0) {
     OC_ERR("*** error deriving Recipient key ###");
     goto add_oscore_context_error;
@@ -483,7 +486,7 @@ oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
   OC_DBG_OSCORE("### \t\tderiving Common IV ###");
   if (oc_oscore_context_derive_param(
         NULL, 0, ctx->idctx, ctx->idctx_len, "IV", (uint8_t *)mastersecret,
-        mastersecret_size, NULL, 0, ctx->commoniv, OSCORE_COMMON_IV_LEN) < 0) {
+        mastersecret_size, salt, salt_size, ctx->commoniv, OSCORE_COMMON_IV_LEN) < 0) {
     OC_ERR("*** error deriving Common IV ###");
     goto add_oscore_context_error;
   }

--- a/security/oc_oscore_context.c
+++ b/security/oc_oscore_context.c
@@ -346,9 +346,9 @@ oc_oscore_context_t *
 oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
                       const char *recipientid, int recipientid_size,
                       uint64_t ssn, const char *desc, const char *mastersecret,
-                      int mastersecret_size, const char *salt,
-                      int salt_size, const char *osc_ctx,
-                      int osc_ctx_size, int auth_at_index, bool from_storage)
+                      int mastersecret_size, const char *salt, int salt_size,
+                      const char *osc_ctx, int osc_ctx_size, int auth_at_index,
+                      bool from_storage)
 {
   PRINT("-----oc_oscore_add_context--SID:");
   oc_char_println_hex(senderid, senderid_size);
@@ -458,8 +458,8 @@ oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
   OC_DBG_OSCORE("### \t\tderiving Sender key ###");
   if (oc_oscore_context_derive_param(
         ctx->sendid, ctx->sendid_len, ctx->idctx, ctx->idctx_len, "Key",
-        (uint8_t *)mastersecret, mastersecret_size, salt, salt_size, ctx->sendkey,
-        OSCORE_KEY_LEN) < 0) {
+        (uint8_t *)mastersecret, mastersecret_size, salt, salt_size,
+        ctx->sendkey, OSCORE_KEY_LEN) < 0) {
     OC_ERR("*** error deriving Sender key ###");
     goto add_oscore_context_error;
   }
@@ -472,8 +472,8 @@ oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
   OC_DBG_OSCORE("### \t\tderiving Recipient key ###");
   if (oc_oscore_context_derive_param(
         ctx->recvid, ctx->recvid_len, ctx->idctx, ctx->idctx_len, "Key",
-        (uint8_t *)mastersecret, mastersecret_size, salt, salt_size, ctx->recvkey,
-        OSCORE_KEY_LEN) < 0) {
+        (uint8_t *)mastersecret, mastersecret_size, salt, salt_size,
+        ctx->recvkey, OSCORE_KEY_LEN) < 0) {
     OC_ERR("*** error deriving Recipient key ###");
     goto add_oscore_context_error;
   }
@@ -484,9 +484,10 @@ oc_oscore_add_context(size_t device, const char *senderid, int senderid_size,
   OC_LOGbytes_OSCORE(ctx->recvkey, OSCORE_KEY_LEN);
 
   OC_DBG_OSCORE("### \t\tderiving Common IV ###");
-  if (oc_oscore_context_derive_param(
-        NULL, 0, ctx->idctx, ctx->idctx_len, "IV", (uint8_t *)mastersecret,
-        mastersecret_size, salt, salt_size, ctx->commoniv, OSCORE_COMMON_IV_LEN) < 0) {
+  if (oc_oscore_context_derive_param(NULL, 0, ctx->idctx, ctx->idctx_len, "IV",
+                                     (uint8_t *)mastersecret, mastersecret_size,
+                                     salt, salt_size, ctx->commoniv,
+                                     OSCORE_COMMON_IV_LEN) < 0) {
     OC_ERR("*** error deriving Common IV ###");
     goto add_oscore_context_error;
   }

--- a/security/oc_oscore_context.h
+++ b/security/oc_oscore_context.h
@@ -151,6 +151,8 @@ void oc_oscore_free_contexts_at_id(int auth_at_index);
 
  * @param mastersecret the OSCORE master secret
  * @param mastersecret_size the length of the OSCORE master secret
+ * @param mastersecret the salt
+ * @param mastersecret_size the length of the salt
  * @param token_id the token
  * @param token_id_size the length of the token_id
  * @param auth_at_index index in the auth at table -1.
@@ -163,7 +165,8 @@ void oc_oscore_free_contexts_at_id(int auth_at_index);
 oc_oscore_context_t *oc_oscore_add_context(
   size_t device, const char *senderid, int senderid_size,
   const char *recipientid, int recipientid_size, uint64_t ssn, const char *desc,
-  const char *mastersecret, int mastersecret_size, const char *token_id,
+  const char *mastersecret, int mastersecret_size, const char *salt,
+                      int salt_size, const char *token_id,
   int token_id_size, int auth_at_index, bool from_storage);
 
 /**

--- a/security/oc_oscore_context.h
+++ b/security/oc_oscore_context.h
@@ -166,8 +166,8 @@ oc_oscore_context_t *oc_oscore_add_context(
   size_t device, const char *senderid, int senderid_size,
   const char *recipientid, int recipientid_size, uint64_t ssn, const char *desc,
   const char *mastersecret, int mastersecret_size, const char *salt,
-                      int salt_size, const char *token_id,
-  int token_id_size, int auth_at_index, bool from_storage);
+  int salt_size, const char *token_id, int token_id_size, int auth_at_index,
+  bool from_storage);
 
 /**
  * @brief Free the least recently used recipient context

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -208,7 +208,8 @@ oc_oscore_recv_message(oc_message_t *message)
           oc_string(at_entry->osc_id), /* recipient id */
           oc_byte_string_len(at_entry->osc_id), /* recipient id len */
           0, "desc", oc_string(at_entry->osc_ms),
-          oc_byte_string_len(at_entry->osc_ms), oscore_pkt->kid_ctx,
+          oc_byte_string_len(at_entry->osc_ms), oc_string(at_entry->osc_salt),
+          oc_byte_string_len(at_entry->osc_salt), oscore_pkt->kid_ctx,
           oscore_pkt->kid_ctx_len, idx, false);
 
         // if context is null, free one & try adding again
@@ -221,7 +222,8 @@ oc_oscore_recv_message(oc_message_t *message)
             oc_string(at_entry->osc_id), /* recipient id */
             oc_byte_string_len(at_entry->osc_id), /* recipient id len */
             0, "desc", oc_string(at_entry->osc_ms),
-            oc_byte_string_len(at_entry->osc_ms), oscore_pkt->kid_ctx,
+            oc_byte_string_len(at_entry->osc_ms), oc_string(at_entry->osc_salt),
+          oc_byte_string_len(at_entry->osc_salt), oscore_pkt->kid_ctx,
             oscore_pkt->kid_ctx_len, idx, false);
           if (!oscore_ctx) {
             OC_ERR("***Could not create oscore recipient context!***");

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -223,7 +223,7 @@ oc_oscore_recv_message(oc_message_t *message)
             oc_byte_string_len(at_entry->osc_id), /* recipient id len */
             0, "desc", oc_string(at_entry->osc_ms),
             oc_byte_string_len(at_entry->osc_ms), oc_string(at_entry->osc_salt),
-          oc_byte_string_len(at_entry->osc_salt), oscore_pkt->kid_ctx,
+            oc_byte_string_len(at_entry->osc_salt), oscore_pkt->kid_ctx,
             oscore_pkt->kid_ctx_len, idx, false);
           if (!oscore_ctx) {
             OC_ERR("***Could not create oscore recipient context!***");


### PR DESCRIPTION
Implemented salt for fp/r entries.

Fixed client broker request query format (ep=knx://ia.<iid>.<ia>). iid & ia were included in decimal, but they need to be in hex.

Also fixed a bug with group address not getting freed when deleting an auth/at entry.